### PR TITLE
Fix persona lookup error

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -66,6 +66,8 @@ def rate_limit(ip, limit=60):
 @app.post("/chat")
 def chat(req: Msg, request: Request):
     rate_limit(request.client.host)
+    if req.character not in PROMPTS:
+        raise HTTPException(status_code=404, detail="Persona not found")
     reply = (
         client.chat.completions.create(
             model="gpt-4o-mini",
@@ -83,6 +85,8 @@ def chat(req: Msg, request: Request):
 @app.post("/chat/stream")
 def chat_stream(req: Msg, request: Request):
     rate_limit(request.client.host)
+    if req.character not in PROMPTS:
+        raise HTTPException(status_code=404, detail="Persona not found")
 
     def gen():
         resp = client.chat.completions.create(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -172,3 +172,29 @@ def test_chat_stream(monkeypatch):
         assert resp.status_code == 200
         assert resp.headers['content-type'].startswith('text/event-stream')
         assert resp.text == 'AB'
+
+
+def test_chat_unknown_persona(monkeypatch):
+    _mock_rate_limit(monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(cr.client.chat.completions, 'create', boom)
+    with TestClient(cr.app) as client:
+        resp = client.post('/chat', json={'character': 'bogus', 'message': 'hi'})
+        assert resp.status_code == 404
+        assert resp.json() == {'detail': 'Persona not found'}
+
+
+def test_chat_stream_unknown_persona(monkeypatch):
+    _mock_rate_limit(monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(cr.client.chat.completions, 'create', boom)
+    with TestClient(cr.app) as client:
+        resp = client.post('/chat/stream', json={'character': 'bogus', 'message': 'hi'})
+        assert resp.status_code == 404
+        assert resp.json() == {'detail': 'Persona not found'}


### PR DESCRIPTION
## Summary
- validate persona IDs in `/chat` and `/chat/stream`
- test both endpoints reject unknown personas

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*