### PR TITLE
Fix SSE output format

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -99,7 +99,8 @@ def chat_stream(req: Msg, request: Request):
         )
         for c in resp:
             if "content" in c.choices[0].delta:
-                yield c.choices[0].delta.content
+                token = c.choices[0].delta.content
+                yield f"data: {token}\n\n"
 
     return StreamingResponse(gen(), media_type="text/event-stream")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,7 +171,7 @@ def test_chat_stream(monkeypatch):
         resp = client.post('/chat/stream', json={'character': 'blueprint-nova', 'message': 'hey'})
         assert resp.status_code == 200
         assert resp.headers['content-type'].startswith('text/event-stream')
-        assert resp.text == 'AB'
+        assert resp.text == 'data: A\n\ndata: B\n\n'
 
 
 def test_chat_unknown_persona(monkeypatch):


### PR DESCRIPTION
## Summary
- yield tokens as `data:` lines for SSE
- expect SSE format in chat streaming test

## Testing
- `pip install pytest` *(fails: Could not connect to proxy)*
- `python -m pytest -q` *(fails: No module named pytest)*