### PR TITLE
Fix chat widget DOM references

### DIFF
--- a/clients/web/chat_widget.html
+++ b/clients/web/chat_widget.html
@@ -2,16 +2,19 @@
 <select id=c></select><br><textarea id=m rows=3 cols=60></textarea>
 <button onclick="s()">Send</button><pre id=o></pre>
 <script>
+const select = document.getElementById('c');
+const msg = document.getElementById('m');
+const out = document.getElementById('o');
 fetch('/manifest')
   .then(r => r.json())
   .then(m => {
     Object.keys(m).forEach(id => {
-      c.innerHTML += `<option>${id}</option>`;
+      select.innerHTML += `<option>${id}</option>`;
     });
   });
 function s(){
   fetch('/chat',{method:'POST',headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({character:c.value,message:m.value})})
-  .then(r=>r.json()).then(j=>o.textContent+=j.reply+"\n");
+    body:JSON.stringify({character:select.value,message:msg.value})})
+  .then(r=>r.json()).then(j=>out.textContent+=j.reply+"\n");
 }
 </script>


### PR DESCRIPTION
## Summary
- refactor `chat_widget.html` to fetch DOM elements once using `document.getElementById`

## Testing
- `python -m pytest` *(fails: No module named pytest)*