### PR TITLE
Handle --dir additively for persona loading

### DIFF
--- a/persona_selector.py
+++ b/persona_selector.py
@@ -4,7 +4,8 @@
 This script can run interactively or via command-line options. Use ``--merge``
 to combine a persona's instruction and knowledge files. Provide ``--output`` to
 write the merged text to a file, otherwise it is printed to ``stdout``.
-Specify ``--dir`` to add an extra search location for persona files.
+Specify ``--dir`` to add an extra search location for persona files alongside
+the built-in ``personas`` folder.
 """
 
 import argparse
@@ -155,7 +156,12 @@ def main() -> None:
     if args.dir:
         extra = os.path.abspath(args.dir)
         SEARCH_DIRS.insert(0, extra)
-        PERSONAS = load_personas([extra])
+        PERSONAS = load_personas(
+            [
+                extra,
+                os.path.join(BASE_DIR, "personas"),
+            ]
+        )
     else:
         PERSONAS = load_personas([os.path.join(BASE_DIR, "personas")])
     MENU = build_menu(PERSONAS)

--- a/tests/test_persona_selector.py
+++ b/tests/test_persona_selector.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import persona_selector as ps
 import pytest
 
@@ -121,3 +122,29 @@ def test_merge_files_write_failure(tmp_path, monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "Failed to write to" in captured.out
+
+
+def test_builtin_personas_available_with_dir(tmp_path, monkeypatch, capsys):
+    base_root = tmp_path / "base"
+    extra_root = tmp_path / "extra"
+    builtins_dir = base_root / "personas"
+    builtin = builtins_dir / "base"
+    extra = extra_root / "custom"
+
+    builtin.mkdir(parents=True)
+    extra.mkdir(parents=True)
+
+    (builtin / "instruction.txt").write_text("b")
+    (builtin / "knowledge.txt").write_text("b")
+    (extra / "instruction.txt").write_text("c")
+    (extra / "knowledge.txt").write_text("c")
+
+    monkeypatch.setattr(ps, "BASE_DIR", str(base_root))
+    monkeypatch.setattr(ps, "SEARCH_DIRS", [str(base_root), str(builtins_dir)])
+    monkeypatch.setattr(sys, "argv", ["prog", "--dir", str(extra_root), "--list"])
+
+    ps.main()
+    captured = capsys.readouterr()
+
+    assert "base" in captured.out
+    assert "custom" in captured.out


### PR DESCRIPTION
## Summary
- keep builtin personas available when using `--dir`
- add test covering additive directory behavior
- clarify docs on default personas

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*