### PR TITLE
Add Unity integration doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,8 @@ Need this in a game, robot, or chatbot?
 Grab the stubs in **`/sdk`** and call `/chat`, `/manifest` (JSON), or `/manifest.yaml` (YAML) from Python, JS, C#, or any language that can hit HTTP — no extra dependencies required.
 
 For details on how the `manifest.yaml` file powers the character system and how to add your own entries, see [docs/manifest_system.md](docs/manifest_system.md).
+
+### Game Engine Integration
+Looking to embed GPT Frenzy in a game engine? Check the
+[Unity integration guide](docs/unity_integration.md) for a simple
+`MonoBehaviour` example that uses the C# client.

--- a/docs/unity_integration.md
+++ b/docs/unity_integration.md
@@ -1,0 +1,44 @@
+# Unity Integration
+
+Import the lightweight C# client so your game can talk to the GPT Frenzy server.
+
+## Importing `GptFrenzyClient.cs`
+1. Copy `sdk/csharp/GptFrenzyClient.cs` into your Unity project (for example
+   into `Assets/Scripts`).
+2. The file only depends on `Newtonsoft.Json` and `System.Net.Http`, which are
+   included with recent Unity versions.
+
+## Example `MonoBehaviour`
+Below is a simple component that sends a message whenever you press the Space
+bar. The reply is printed to the Console.
+
+```csharp
+using UnityEngine;
+
+public class ChatExample : MonoBehaviour
+{
+    private GptFrenzyClient _client;
+
+    void Start()
+    {
+        // Point to your API base URL
+        _client = new GptFrenzyClient("http://localhost:8000");
+    }
+
+    async void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            string reply = await _client.Chat("blueprint-nova", "Hello from Unity!");
+            Debug.Log(reply);
+        }
+    }
+}
+```
+
+## Base URL and async notes
+- Pass the server address to the constructor if it is not running on
+  `http://localhost:8000`.
+- `Chat` returns a `Task<string>` so you can `await` it inside an async method.
+- To stream partial tokens, implement a `ChatStream` method that consumes
+  `/chat/stream` and yield each token as it arrives.


### PR DESCRIPTION
## Summary
- document how to import `GptFrenzyClient.cs` into Unity
- show a sample `MonoBehaviour` using the client
- link the guide from README under a new *Game Engine Integration* section

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `black . --check` *(fails: would reformat several files)*