### PR TITLE
Add streaming client APIs for JS and C#

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,5 +1,5 @@
 # GPTFrenzy SDK stubs
-Thin, dependency-free wrappers around the `/chat` and `/manifest` endpoints.  
+Thin, dependency-free wrappers around the `/chat`, `/chat/stream`, and `/manifest` endpoints.
 Use whichever language matches your engine:
 
 | Language | File | Example |
@@ -12,3 +12,20 @@ All wrappers assume the FastAPI server is reachable at `http://localhost:8000`
 (or whatever base URL you pass).
 Calls that result in non-2xx responses will reject their returned promises with
 an `Error` containing the HTTP status code.
+
+## Streaming usage
+
+To consume streaming replies, use the `chatStream`/`ChatStream` helpers:
+
+```js
+for await (const tok of chatStream(url, 'blueprint-nova', 'Hi')) {
+  console.log(tok);
+}
+```
+
+```csharp
+await foreach (var tok in client.ChatStream("blueprint-nova", "Hi"))
+{
+    Console.Write(tok);
+}
+```

--- a/sdk/csharp/GptFrenzyClient.cs
+++ b/sdk/csharp/GptFrenzyClient.cs
@@ -1,6 +1,8 @@
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.IO;
 using Newtonsoft.Json;
 
 public class GptFrenzyClient
@@ -22,6 +24,27 @@ public class GptFrenzyClient
         resp.EnsureSuccessStatusCode();
         dynamic body = JsonConvert.DeserializeObject(await resp.Content.ReadAsStringAsync());
         return (string)body.reply;
+    }
+
+    public async IAsyncEnumerable<string> ChatStream(string character, string message)
+    {
+        var payload = JsonConvert.SerializeObject(new { character, message });
+        using var req = new HttpRequestMessage(HttpMethod.Post, $"{_base}/chat/stream")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+        var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
+        resp.EnsureSuccessStatusCode();
+        var stream = await resp.Content.ReadAsStreamAsync();
+        using var reader = new StreamReader(stream);
+        while (true)
+        {
+            var line = await reader.ReadLineAsync();
+            if (line == null)
+                yield break;
+            if (line.StartsWith("data: "))
+                yield return line.Substring(6);
+        }
     }
 
     public async Task<dynamic> Manifest()

--- a/sdk/js/gptfrenzy-client.js
+++ b/sdk/js/gptfrenzy-client.js
@@ -12,6 +12,36 @@ export async function chat(baseUrl, character, message) {
   return json.reply;
 }
 
+export async function* chatStream(baseUrl, character, message) {
+  const r = await fetch(`${baseUrl.replace(/\/$/, '')}/chat/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ character, message })
+  });
+  if (!r.ok) {
+    throw new Error(`HTTP ${r.status}`);
+  }
+  const reader = r.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf('\n\n')) >= 0) {
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      if (line.startsWith('data: ')) {
+        yield line.slice(6);
+      }
+    }
+  }
+  if (buf.startsWith('data: ')) {
+    yield buf.slice(6);
+  }
+}
+
 export async function manifest(baseUrl) {
   const r = await fetch(`${baseUrl.replace(/\/$/, '')}/manifest`);
   if (!r.ok) {

--- a/tests/test_csharp_client.py
+++ b/tests/test_csharp_client.py
@@ -1,0 +1,99 @@
+import http.server
+import socketserver
+import threading
+import subprocess
+import textwrap
+from pathlib import Path
+import shutil
+import tempfile
+import pytest
+
+
+def _dotnet():
+    return shutil.which("dotnet")
+
+
+@pytest.mark.skipif(_dotnet() is None, reason="dotnet executable not found")
+def test_csharp_client_streaming():
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b"data: A\n\n")
+            self.wfile.write(b"data: B\n\n")
+
+        def log_message(self, *args):
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            port = server.server_address[1]
+            tmp = Path(tempfile.mkdtemp())
+            subprocess.check_call([_dotnet(), "new", "console", "--output", str(tmp)])
+            root = Path(__file__).resolve().parents[1]
+            (tmp / "GptFrenzyClient.cs").write_text(Path(root / "sdk/csharp/GptFrenzyClient.cs").read_text())
+            (tmp / "Program.cs").write_text(textwrap.dedent(f"""
+using System;
+using System.Threading.Tasks;
+class Program {{
+    static async Task Main() {{
+        var c = new GptFrenzyClient("http://127.0.0.1:{port}");
+        string res = "";
+        await foreach (var t in c.ChatStream("x","y")) {{ res += t; }}
+        Console.WriteLine("out:" + res);
+    }}
+}}
+"""))
+            result = subprocess.run([_dotnet(), "run", "--project", str(tmp)], capture_output=True, text=True)
+            assert "out:AB" in result.stdout
+        finally:
+            server.shutdown()
+            thread.join()
+
+
+@pytest.mark.skipif(_dotnet() is None, reason="dotnet executable not found")
+def test_csharp_client_stream_error():
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+        def log_message(self, *args):
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            port = server.server_address[1]
+            tmp = Path(tempfile.mkdtemp())
+            subprocess.check_call([_dotnet(), "new", "console", "--output", str(tmp)])
+            root = Path(__file__).resolve().parents[1]
+            (tmp / "GptFrenzyClient.cs").write_text(Path(root / "sdk/csharp/GptFrenzyClient.cs").read_text())
+            (tmp / "Program.cs").write_text(textwrap.dedent(f"""
+using System;
+using System.Threading.Tasks;
+class Program {{
+    static async Task Main() {{
+        try {{
+            var c = new GptFrenzyClient("http://127.0.0.1:{port}");
+            await foreach (var _ in c.ChatStream("x","y")) {{ }}
+            Console.WriteLine("no-error");
+        }} catch (Exception e) {{
+            Console.WriteLine("err:" + e.Message);
+        }}
+    }}
+}}
+"""))
+            result = subprocess.run([_dotnet(), "run", "--project", str(tmp)], capture_output=True, text=True)
+            assert "err:" in result.stdout
+        finally:
+            server.shutdown()
+            thread.join()
+

--- a/tests/test_js_client.py
+++ b/tests/test_js_client.py
@@ -44,3 +44,84 @@ def test_js_client_rejects_on_error():
         finally:
             server.shutdown()
             thread.join()
+
+
+def _run_node(script: str, root: Path):
+    return subprocess.run(["node", "-e", script], capture_output=True, text=True, cwd=root)
+
+
+def test_js_client_streaming():
+    if shutil.which("node") is None:
+        pytest.skip("node executable not found")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b"data: A\n\n")
+            self.wfile.write(b"data: B\n\n")
+
+        def log_message(self, *args):
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            port = server.server_address[1]
+            script = textwrap.dedent(
+                f"""
+                import {{ chatStream }} from './sdk/js/gptfrenzy-client.js';
+                let out = '';
+                for await (const t of chatStream('http://127.0.0.1:{port}', 'x', 'y')) {{
+                    out += t;
+                }}
+                console.log('out:' + out);
+                """
+            )
+            root = Path(__file__).resolve().parents[1]
+            result = _run_node(script, root)
+            assert "out:AB" in result.stdout
+        finally:
+            server.shutdown()
+            thread.join()
+
+
+def test_js_client_stream_error():
+    if shutil.which("node") is None:
+        pytest.skip("node executable not found")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+        def log_message(self, *args):
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            port = server.server_address[1]
+            script = textwrap.dedent(
+                f"""
+                import {{ chatStream }} from './sdk/js/gptfrenzy-client.js';
+                try {{
+                    for await (const _ of chatStream('http://127.0.0.1:{port}', 'x', 'y')) {{}}
+                    console.log('no-error');
+                }} catch (e) {{
+                    console.log('err:' + String(e));
+                }}
+                """
+            )
+            root = Path(__file__).resolve().parents[1]
+            result = _run_node(script, root)
+            assert "err:HTTP 500" in result.stdout
+        finally:
+            server.shutdown()
+            thread.join()


### PR DESCRIPTION
## Summary
- support `/chat/stream` in the JS SDK and throw on non‐200
- add `ChatStream` async iterator in C# SDK
- document streaming usage in the SDK README
- add tests for streaming clients

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*