### PR TITLE
Add Unity integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,4 @@ Grab the stubs in **`/sdk`** and call `/chat`, `/manifest` (JSON), or `/manifest
 
 For details on how the `manifest.yaml` file powers the character system and how to add your own entries, see [docs/manifest_system.md](docs/manifest_system.md).
 To deploy a persona directory in another host (Discord, Unreal, Unity), follow the steps in [docs/spawn_system.md](docs/spawn_system.md).
+For a Unity-specific C# example using `GptFrenzyClient`, see [docs/unity_integration.md](docs/unity_integration.md).

--- a/docs/unity_integration.md
+++ b/docs/unity_integration.md
@@ -1,0 +1,39 @@
+# Using GptFrenzyClient.cs in Unity
+
+This quick guide shows how to drop the **C#** SDK into a Unity project and send messages to your GPT Frenzy server.
+
+1. Copy `sdk/csharp/GptFrenzyClient.cs` into your Unity project's `Assets` folder (any location is fine).
+2. When you create the client, set the base URL for your running server:
+   ```csharp
+   var client = new GptFrenzyClient("http://localhost:8000");
+   ```
+3. The `Chat()` and `ChatStream()` methods return `Task` values, so you must handle them asynchronously in Unity (e.g., use `async` methods or coroutines).
+
+Below is a minimal `MonoBehaviour` that sends a message every time the **Space** key is pressed and prints the reply to the console:
+
+```csharp
+using UnityEngine;
+using System.Threading.Tasks;
+
+public class FrenzyExample : MonoBehaviour
+{
+    GptFrenzyClient client;
+
+    void Start()
+    {
+        // Point this URL to your running GPT Frenzy server
+        client = new GptFrenzyClient("http://localhost:8000");
+    }
+
+    async void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            string reply = await client.Chat("demo-character", "Hello!");
+            Debug.Log(reply);
+        }
+    }
+}
+```
+
+To stream tokens instead of waiting for the full reply, call `ChatStream()` inside an `async` method and iterate with `await foreach`.


### PR DESCRIPTION
## Summary
- document how to use `GptFrenzyClient.cs` inside a Unity project
- link new doc from the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*