### PR TITLE
Add Python streaming client

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -15,12 +15,17 @@ an `Error` containing the HTTP status code.
 
 ## Streaming usage
 
-To consume streaming replies, use the `chatStream`/`ChatStream` helpers:
+To consume streaming replies, use the `chat_stream`/`chatStream`/`ChatStream` helpers:
 
 ```js
 for await (const tok of chatStream(url, 'blueprint-nova', 'Hi')) {
   console.log(tok);
 }
+```
+
+```python
+for tok in bot.chat_stream('blueprint-nova', 'Hi'):
+    print(tok, end='')
 ```
 
 ```csharp

--- a/sdk/python/gptfrenzy_client.py
+++ b/sdk/python/gptfrenzy_client.py
@@ -2,7 +2,7 @@ import requests, json, typing as _t
 
 
 class GPTFrenzyClient:
-    """Super-light client—no asyncio, no streaming."""
+    """Super-light client for GPTFrenzy."""
 
     def __init__(self, base_url: str = "http://localhost:8000"):
         self.base = base_url.rstrip("/")
@@ -15,6 +15,22 @@ class GPTFrenzyClient:
         )
         r.raise_for_status()
         return r.json()["reply"]
+
+    def chat_stream(self, character: str, message: str) -> _t.Iterator[str]:
+        """Yield the reply as tokens using server-sent events."""
+        r = requests.post(
+            f"{self.base}/chat/stream",
+            json={"character": character, "message": message},
+            stream=True,
+            timeout=30,
+        )
+        r.raise_for_status()
+        try:
+            for line in r.iter_lines(decode_unicode=True):
+                if line.startswith("data: "):
+                    yield line[6:]
+        finally:
+            r.close()
 
     def manifest(self) -> _t.List[dict]:
         return requests.get(f"{self.base}/manifest", timeout=10).json()

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -1,0 +1,59 @@
+import http.server
+import socketserver
+import threading
+import pytest
+
+from sdk.python import gptfrenzy_client as gfc
+
+
+class _BaseHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+
+def _serve(handler_cls):
+    return socketserver.TCPServer(("127.0.0.1", 0), handler_cls)
+
+
+def test_python_client_streaming():
+    class Handler(_BaseHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b"data: A\n\n")
+            self.wfile.write(b"data: B\n\n")
+
+    with _serve(Handler) as server:
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            port = server.server_address[1]
+            c = gfc.GPTFrenzyClient(f"http://127.0.0.1:{port}")
+            out = "".join(c.chat_stream("x", "y"))
+            assert out == "AB"
+        finally:
+            server.shutdown()
+            thread.join()
+
+
+def test_python_client_stream_error():
+    class Handler(_BaseHandler):
+        def do_POST(self):
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+    with _serve(Handler) as server:
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            port = server.server_address[1]
+            c = gfc.GPTFrenzyClient(f"http://127.0.0.1:{port}")
+            with pytest.raises(Exception):
+                list(c.chat_stream("x", "y"))
+        finally:
+            server.shutdown()
+            thread.join()


### PR DESCRIPTION
## Summary
- extend the Python SDK with a `chat_stream` generator for SSE streaming
- add tests validating the Python streaming client
- document Python streaming usage in SDK README

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*