### PR TITLE
Add configurable model

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The API reads a few settings from the environment. When using
 `docker-compose.yml` you can override these values:
 
 - `OPENAI_API_KEY` – your OpenAI authentication key.
+- `OPENAI_MODEL` – OpenAI model name (default: `gpt-4o-mini`).
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).
 - `REDIS_PORT` – port for Redis (default: `6379`).

--- a/api/character_router.py
+++ b/api/character_router.py
@@ -10,6 +10,9 @@ import pathlib
 import openai
 
 client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+# Allow callers to set the OpenAI model via env with a sensible default so we
+# can easily swap models when deploying.
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 BASE = pathlib.Path(__file__).parent.parent
 PERSONA_DIR = BASE / "personas"
 MANIFEST = BASE / "manifest.yaml"
@@ -70,7 +73,7 @@ def chat(req: Msg, request: Request):
         raise HTTPException(status_code=404, detail="Persona not found")
     reply = (
         client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=OPENAI_MODEL,
             messages=[
                 {"role": "system", "content": PROMPTS[req.character]},
                 {"role": "user", "content": req.message},
@@ -90,7 +93,7 @@ def chat_stream(req: Msg, request: Request):
 
     def gen():
         resp = client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=OPENAI_MODEL,
             messages=[
                 {"role": "system", "content": PROMPTS[req.character]},
                 {"role": "user", "content": req.message},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: .
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # Select the OpenAI model used by the API (default: "gpt-4o-mini")
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
       # Optional Redis connection URL. Overrides host/port if set.
       - REDIS_URL=${REDIS_URL}
       # Hostname of the Redis instance used by the API (default: "redis")


### PR DESCRIPTION
## Summary
- allow configuring the OpenAI model via `OPENAI_MODEL` env var
- document the new environment variable
- expose `OPENAI_MODEL` in docker-compose

## Testing
- `pytest -q` *(fails: No module named pytest)*