### PR TITLE
Add Python SDK dependency info

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,6 +1,10 @@
 # GPTFrenzy SDK stubs
-Thin, dependency-free wrappers around the `/chat`, `/chat/stream`, and `/manifest` endpoints.
-Use whichever language matches your engine:
+Lightweight wrappers around the `/chat`, `/chat/stream`, and `/manifest` endpoints.
+Use whichever language matches your engine. The Python client relies on the `requests` library (see `python/requirements.txt`). Install it with:
+
+```bash
+pip install -r python/requirements.txt
+```
 
 | Language | File | Example |
 |----------|------|---------|

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- list `requests` in `sdk/python/requirements.txt`
- mention the Python dependency in the SDK README

## Testing
- `pytest -q` *(fails: command not found)*