### PR TITLE
Handle manifest read errors

### DIFF
--- a/gptfrenzy/spawn.py
+++ b/gptfrenzy/spawn.py
@@ -70,8 +70,11 @@ def launch(host: str, persona_path: str, **kwargs: Any) -> PersonaInstance:
     """Instantiate a persona from ``persona_path`` for the given ``host``."""
     persona_dir = Path(persona_path)
     manifest_file = persona_dir / "manifest.yaml"
-    with open(manifest_file, "r", encoding="utf-8") as f:
-        manifest = yaml.safe_load(f)
+    try:
+        with open(manifest_file, "r", encoding="utf-8") as f:
+            manifest = yaml.safe_load(f)
+    except (FileNotFoundError, yaml.YAMLError) as exc:
+        raise ValueError("manifest.yaml missing or unreadable") from exc
     if manifest.get("sap_version") != "0.3":
         raise ValueError("Unsupported SAP version")
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -45,3 +45,28 @@ def test_invalid_version_raises(tmp_path):
         pass
     else:
         assert False, "ValueError not raised"
+
+
+def test_missing_manifest(tmp_path):
+    d = tmp_path / "persona"
+    d.mkdir()
+    (d / "persona.py").write_text("class Persona:\n    def __init__(self, **k): pass")
+    try:
+        launch("host", str(d))
+    except ValueError as e:
+        assert "manifest.yaml missing or unreadable" in str(e)
+    else:
+        assert False, "ValueError not raised"
+
+
+def test_bad_manifest_yaml(tmp_path):
+    d = tmp_path / "persona"
+    d.mkdir()
+    (d / "manifest.yaml").write_text(":\n")
+    (d / "persona.py").write_text("class Persona:\n    def __init__(self, **k): pass")
+    try:
+        launch("host", str(d))
+    except ValueError as e:
+        assert "manifest.yaml missing or unreadable" in str(e)
+    else:
+        assert False, "ValueError not raised"


### PR DESCRIPTION
## Summary
- handle bad or missing manifest in `spawn.launch`
- test for manifest file errors

## Testing
- `python -m py_compile gptfrenzy/spawn.py tests/test_spawn.py`
- `ruff check gptfrenzy/spawn.py tests/test_spawn.py`