### PR TITLE
Implement configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The API reads a few settings from the environment. When using
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).
 - `REDIS_PORT` – port for Redis (default: `6379`).
+- `ALLOWED_ORIGINS` – comma-separated list for CORS (default: `*`).
 
 ### Updating `openapi.json`
 

--- a/api/character_router.py
+++ b/api/character_router.py
@@ -30,9 +30,17 @@ r = redis.from_url(redis_url, decode_responses=True)
 app = FastAPI()
 
 # --- CORS so browsers, WebGL & mobile apps can hit us directly ----------
+# Allow callers to restrict origins via ALLOWED_ORIGINS. Provide a comma-
+# separated list or "*" for the default open policy.
+_origins = os.getenv("ALLOWED_ORIGINS", "*")
+if _origins == "*":
+    allow_origins = ["*"]
+else:
+    allow_origins = [o.strip() for o in _origins.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- make allowed origins configurable through `ALLOWED_ORIGINS` env var
- document new variable in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*