### PR TITLE
Add baseUrl support for web chat widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ The API reads a few settings from the environment. When using
 Run `python3 app.py --openapi` to regenerate `openapi.json`. This command loads `api.character_router:app` so the resulting spec documents `/chat`, `/chat/stream`, and `/manifest`. Rebuild the file whenever you change those endpoints.
 
 
+## Web Chat Widget
+
+A bare-bones browser client lives in `clients/web/chat_widget.html`. Serve the file
+with any static web host:
+
+```bash
+cd clients/web
+python3 -m http.server 8000
+```
+
+Then visit <http://localhost:8000/chat_widget.html?baseUrl=http://localhost:8000>.
+The widget reads the `baseUrl` query parameter (or a `data-baseurl` attribute on
+the `<script>` tag) and sends requests to `${baseUrl}/manifest` and
+`${baseUrl}/chat`.
+
 ## Company Sandbox Avatar
 
 AccessAI Tech's `Company` persona appears here solely as a demo sandbox and does not represent official policy. Feel free to experiment with it using the helper scripts below.

--- a/clients/web/chat_widget.html
+++ b/clients/web/chat_widget.html
@@ -5,7 +5,9 @@
 const select = document.getElementById('c');
 const msg = document.getElementById('m');
 const out = document.getElementById('o');
-fetch('/manifest')
+const params = new URLSearchParams(location.search);
+const baseUrl = document.currentScript.dataset.baseurl || params.get('baseUrl') || '';
+fetch(`${baseUrl}/manifest`)
   .then(r => r.json())
   .then(m => {
     Object.keys(m).forEach(id => {
@@ -13,7 +15,7 @@ fetch('/manifest')
     });
   });
 function s(){
-  fetch('/chat',{method:'POST',headers:{'Content-Type':'application/json'},
+  fetch(`${baseUrl}/chat`,{method:'POST',headers:{'Content-Type':'application/json'},
     body:JSON.stringify({character:select.value,message:msg.value})})
   .then(r=>r.json()).then(j=>out.textContent+=j.reply+"\n");
 }


### PR DESCRIPTION
## Summary
- let the web chat widget talk to any server via `baseUrl`
- explain how to host the widget in the main README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*