### PR TITLE
Add Discord bot example using spawn system

### DIFF
--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -1,0 +1,17 @@
+# Discord Integration with Spawn System
+
+This example shows how to load a persona with `gptfrenzy.spawn.launch()`
+and respond to messages in Discord.
+
+1. Install `discord.py`:
+   ```bash
+   pip install discord.py
+   ```
+2. Run the bot, passing the persona directory and your Discord token:
+   ```bash
+   python bot.py /path/to/persona YOUR_BOT_TOKEN
+   ```
+   The persona's `generate()` method will be called for every message
+   the bot can see and the result sent back to the same channel.
+
+`bot.py` keeps things minimal so you can adapt it to your needs.

--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -1,0 +1,31 @@
+"""Minimal Discord bot using the spawn system."""
+
+import asyncio
+import os
+import sys
+
+import discord
+
+from gptfrenzy.spawn import launch
+
+
+async def main(persona_dir: str, token: str) -> None:
+    persona = launch("discord", persona_dir)
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+
+    @client.event
+    async def on_message(message: discord.Message) -> None:
+        if message.author.bot:
+            return
+        reply = persona.generate(message.content)
+        await message.channel.send(reply)
+
+    await client.start(token)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python bot.py <persona_dir> <discord_token>")
+        raise SystemExit(1)
+    asyncio.run(main(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
## Summary
- add `clients/discord` folder
- provide minimal `bot.py` demonstrating persona spawn on Discord
- document steps in `clients/discord/README.md`

## Testing
- `pytest -q` *(fails: command not found)*