### PR TITLE
Add Discord message intent setup

### DIFF
--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -7,7 +7,10 @@ and respond to messages in Discord.
    ```bash
    pip install discord.py
    ```
-2. Run the bot, passing the persona directory and your Discord token:
+2. Enable the **Message Content Intent** for your bot in the Discord
+   developer portal so it can read messages. The bot sets
+   `intents.message_content = True` in `bot.py`.
+3. Run the bot, passing the persona directory and your Discord token:
    ```bash
    python bot.py /path/to/persona YOUR_BOT_TOKEN
    ```

--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -12,6 +12,7 @@ from gptfrenzy.spawn import launch
 async def main(persona_dir: str, token: str) -> None:
     persona = launch("discord", persona_dir)
     intents = discord.Intents.default()
+    intents.message_content = True
     client = discord.Client(intents=intents)
 
     @client.event


### PR DESCRIPTION
## Summary
- document enabling the Message Content Intent in Discord client README
- set `intents.message_content = True` in the Discord bot example

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*