### PR TITLE
Handle missing discord.py gracefully

### DIFF
--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -3,7 +3,11 @@
 import asyncio
 import sys
 
-import discord
+try:
+    import discord
+except ImportError:  # pragma: no cover - optional dependency
+    print("Install discord.py (`pip install discord.py`) to use this bot")
+    raise SystemExit(1)
 
 from gptfrenzy.spawn import launch
 


### PR DESCRIPTION
## Summary
- guard discord bot import with try/except ImportError
- instruct users to install discord.py if missing

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*