### PR TITLE
Add prompt_file validation to manifest loader

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -62,8 +62,14 @@ def _load_manifest():
 
     manifest = {}
     for entry in data:
-        if not isinstance(entry, dict) or "id" not in entry:
-            raise ValueError("manifest entries must be dicts containing an 'id'")
+        if (
+            not isinstance(entry, dict)
+            or "id" not in entry
+            or "prompt_file" not in entry
+        ):
+            raise ValueError(
+                "manifest entries must include id and prompt_file"
+            )
         manifest[entry["id"]] = entry
 
     return manifest

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -1,0 +1,11 @@
+import yaml
+import pytest
+import api.character_router as cr
+
+
+def test_manifest_requires_prompt_file(tmp_path, monkeypatch):
+    m = tmp_path / "manifest.yaml"
+    m.write_text(yaml.safe_dump([{"id": "x"}]))
+    monkeypatch.setattr(cr, "MANIFEST", m)
+    with pytest.raises(ValueError):
+        cr._load_manifest()


### PR DESCRIPTION
## Summary
- validate `prompt_file` in `_load_manifest`
- test manifest loader rejects entries missing a prompt file

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*