### PR TITLE
Remove prompt YAML check

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -87,9 +87,6 @@ def _prime_prompts():
             )
         except FileNotFoundError as exc:
             log.warning("Prompt file for '%s' missing: %s", pid, exc)
-        except yaml.YAMLError as exc:
-            log.warning("Invalid YAML for '%s': %s", pid, exc)
-
 
 _prime_prompts()
 


### PR DESCRIPTION
## Summary
- trim `_prime_prompts` by removing YAML error branch

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*