### PR TITLE
Support async speak in personas

### DIFF
--- a/gptfrenzy/spawn.py
+++ b/gptfrenzy/spawn.py
@@ -21,6 +21,7 @@ import yaml
 
 class PersonaInstance:
     """Wrapper around a persona implementation enforcing capability flags."""
+
     def __init__(self, impl: Any, caps: Iterable[str]):
         """Create a new instance backed by ``impl`` with allowed ``caps``."""
 
@@ -37,14 +38,17 @@ class PersonaInstance:
             result = await result
         return result
 
-    def speak(self, audio: Any | None = None) -> Any:
+    async def speak(self, audio: Any | None = None) -> Any:
         """Delegate text-to-speech to the persona if allowed."""
 
         if "voice" not in self.capabilities:
             raise RuntimeError("voice capability unavailable")
         if not hasattr(self._impl, "speak"):
             raise AttributeError("Persona missing speak()")
-        return self._impl.speak(audio)
+        result = self._impl.speak(audio)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return result
 
     def embody(self, *args: Any, **kwargs: Any) -> Any:
         """Forward embodiment data to the persona if supported."""

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -71,3 +71,24 @@ def test_bad_manifest_yaml(tmp_path):
         assert "manifest.yaml missing or unreadable" in str(e)
     else:
         assert False, "ValueError not raised"
+
+
+def test_async_speak(tmp_path):
+    d = tmp_path / "persona"
+    d.mkdir()
+    manifest = {
+        "sap_version": "0.3",
+        "entrypoint": "gptfrenzy.spawn:launch",
+        "assets": [],
+        "capabilities": ["text", "voice"],
+        "license_ref": "./LICENSE_PERSONAS",
+    }
+    (d / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+    (d / "persona.py").write_text(
+        "class Persona:\n"
+        "    def __init__(self, **k): pass\n"
+        "    async def generate(self, t): return t\n"
+        "    async def speak(self, a=None): return 'async'"
+    )
+    inst = launch("host", str(d))
+    assert asyncio.run(inst.speak()) == "async"


### PR DESCRIPTION
## Summary
- handle async persona speak methods
- add test for async speak handling

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*