### PR TITLE
Handle login failures in Discord client

### DIFF
--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -38,7 +38,11 @@ async def main(persona_dir: str, token: str) -> None:
         else:
             await message.channel.send(reply)
 
-    await client.start(token)
+    try:
+        await client.start(token)
+    except discord.LoginFailure:
+        log.error("Invalid Discord token")
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- exit with a clear message when Discord credentials are invalid

## Testing
- `black clients/discord/bot.py`
- `python3 -m pip install -r requirements-dev.txt` *(fails: No route to host)*
- `pytest -q` *(fails: command not found)*