### PR TITLE
Fix manifest route test client usage

### DIFF
--- a/tests/test_manifest_route.py
+++ b/tests/test_manifest_route.py
@@ -3,8 +3,8 @@ from api.character_router import app, MANIFEST
 
 
 def test_manifest_yaml_route():
-    client = TestClient(app)
-    resp = client.get("/manifest.yaml")
-    assert resp.status_code == 200
-    assert resp.headers["content-type"].startswith("text/plain")
-    assert resp.text == MANIFEST.read_text(encoding="utf-8")
+    with TestClient(app) as client:
+        resp = client.get("/manifest.yaml")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert resp.text == MANIFEST.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- use context manager for TestClient in tests

## Testing
- `pytest -q` *(fails: command not found)*