### PR TITLE
Improve manifest validation

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -61,15 +61,21 @@ def _load_manifest():
         raise ValueError("manifest must be a list of entries")
 
     manifest = {}
-    for entry in data:
-        if (
-            not isinstance(entry, dict)
-            or "id" not in entry
-            or "prompt_file" not in entry
-        ):
+    for idx, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Invalid manifest entry at {MANIFEST}:{idx}")
+
+        missing = [
+            key
+            for key in ("id", "prompt_file", "entrypoint")
+            if not entry.get(key)
+        ]
+        if missing:
+            missing_keys = ", ".join(missing)
             raise ValueError(
-                "manifest entries must include id and prompt_file"
+                f"Manifest entry {MANIFEST}:{idx} missing {missing_keys}"
             )
+
         manifest[entry["id"]] = entry
 
     return manifest

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,12 @@
 - id: blueprint-nova
   name: Blueprint Nova
   prompt_file: blueprint_nova.md
+  entrypoint: gptfrenzy.spawn:launch
   voice_id: alloy
   avatar_url: https://example.com/blueprint_nova.png
 - id: blueprint-hustler
   name: Blueprint Hustler
   prompt_file: blueprint_hustler.md
+  entrypoint: gptfrenzy.spawn:launch
   voice_id: echo
   avatar_url: https://example.com/bph.png

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -5,7 +5,33 @@ import api.character_router as cr
 
 def test_manifest_requires_prompt_file(tmp_path, monkeypatch):
     m = tmp_path / "manifest.yaml"
-    m.write_text(yaml.safe_dump([{"id": "x"}]))
+    m.write_text(yaml.safe_dump([{"id": "x", "entrypoint": "e"}]))
+    monkeypatch.setattr(cr, "MANIFEST", m)
+    with pytest.raises(ValueError):
+        cr._load_manifest()
+
+
+def test_manifest_requires_entrypoint(tmp_path, monkeypatch):
+    m = tmp_path / "manifest.yaml"
+    m.write_text(yaml.safe_dump([{"id": "x", "prompt_file": "p"}]))
+    monkeypatch.setattr(cr, "MANIFEST", m)
+    with pytest.raises(ValueError):
+        cr._load_manifest()
+
+
+def test_manifest_requires_id(tmp_path, monkeypatch):
+    m = tmp_path / "manifest.yaml"
+    m.write_text(yaml.safe_dump([{"prompt_file": "p", "entrypoint": "e"}]))
+    monkeypatch.setattr(cr, "MANIFEST", m)
+    with pytest.raises(ValueError):
+        cr._load_manifest()
+
+
+def test_manifest_must_be_list(tmp_path, monkeypatch):
+    m = tmp_path / "manifest.yaml"
+    m.write_text(
+        yaml.safe_dump({"id": "x", "prompt_file": "p", "entrypoint": "e"})
+    )
     monkeypatch.setattr(cr, "MANIFEST", m)
     with pytest.raises(ValueError):
         cr._load_manifest()


### PR DESCRIPTION
## Summary
- validate the manifest more thoroughly when the API loads it
- add entrypoint fields to example manifest
- expand manifest validation tests

## Testing
- `pytest -q` *(fails: `pytest` not found)*