### PR TITLE
Async-safe Persona hooks

### DIFF
--- a/gptfrenzy/persona_loader.py
+++ b/gptfrenzy/persona_loader.py
@@ -5,13 +5,13 @@ spawn system. Real persona modules may override some or all methods, but the
 protocol consists of three optional hooks in addition to initialization:
 
 ``generate(text)``
-    Return the persona's textual response to ``text``.
+    Coroutine returning the persona's textual response to ``text``.
 
 ``speak(audio=None)``
-    Handle text-to-speech or audio processing if the persona supports voice.
+    Coroutine that handles text-to-speech or audio processing if supported.
 
 ``embody(*args, **kwargs)``
-    Consume realtime embodiment data for animation or other effects.
+    Coroutine consuming realtime embodiment data for animation or other effects.
 """
 
 
@@ -26,17 +26,17 @@ class Persona:
         self.host = host
         self.path = persona_path
 
-    def generate(self, text: str):
+    async def generate(self, text: str):
         """Return the persona's response to ``text``."""
 
         return text
 
-    def speak(self, audio=None):
+    async def speak(self, audio=None):
         """Optionally process or synthesize ``audio``."""
 
         return audio
 
-    def embody(self, *args, **kwargs):
+    async def embody(self, *args, **kwargs):
         """Accept realtime embodiment data."""
 
         return None

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -94,6 +94,27 @@ def test_async_speak(tmp_path):
     assert asyncio.run(inst.speak()) == "async"
 
 
+def test_async_embody(tmp_path):
+    d = tmp_path / "persona"
+    d.mkdir()
+    manifest = {
+        "sap_version": "0.3",
+        "entrypoint": "gptfrenzy.spawn:launch",
+        "assets": [],
+        "capabilities": ["text", "realtime_embodiment"],
+        "license_ref": "./LICENSE_PERSONAS",
+    }
+    (d / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+    (d / "persona.py").write_text(
+        "class Persona:\n"
+        "    def __init__(self, **k): pass\n"
+        "    async def generate(self, t): return t\n"
+        "    async def embody(self, *a, **kw): return 'done'"
+    )
+    inst = launch("host", str(d))
+    assert asyncio.run(inst.embody()) == "done"
+
+
 def test_custom_entrypoint(tmp_path):
     d = tmp_path / "persona"
     d.mkdir()


### PR DESCRIPTION
## Summary
- declare core Persona hooks as async coroutines
- update protocol docstring
- test async embody functionality

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*