### PR TITLE
Ensure directories exist before writing files

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
 import json
 import sys
+from pathlib import Path
 from fastapi import Body, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import persona_selector as ps
+from gptfrenzy.utils import ensure_parent_dirs
 
 app = FastAPI(title="Persona Selector API")
 app.add_middleware(
@@ -59,7 +61,9 @@ if __name__ == "__main__":
         # Mount the character API so our spec includes those routes
         app.include_router(character_app.router)
 
-        with open("openapi.json", "w", encoding="utf-8") as f:
+        path = Path("openapi.json")
+        ensure_parent_dirs(path)
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(app.openapi(), f, indent=2)
     else:
         import uvicorn

--- a/gptfrenzy/spawn.py
+++ b/gptfrenzy/spawn.py
@@ -18,6 +18,8 @@ import asyncio
 
 import yaml
 
+from .utils import ensure_parent_dirs
+
 
 class PersonaInstance:
     """Wrapper around a persona implementation enforcing capability flags."""
@@ -115,6 +117,7 @@ def make_manifest(persona_dir: str) -> Path:
         "capabilities": ["text"],
         "license_ref": "./LICENSE_PERSONAS",
     }
+    ensure_parent_dirs(path)
     with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(manifest, f, sort_keys=False)
     return path

--- a/gptfrenzy/utils.py
+++ b/gptfrenzy/utils.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def ensure_parent_dirs(path: Path) -> None:
+    """Create parent directories for ``path`` if they do not exist."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)

--- a/persona_selector.py
+++ b/persona_selector.py
@@ -10,7 +10,10 @@ the built-in ``personas`` folder.
 
 import argparse
 import os
+from pathlib import Path
 from typing import Dict, List, Tuple
+
+from gptfrenzy.utils import ensure_parent_dirs
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # Default search locations for persona files. ``main()`` resets this list
@@ -98,6 +101,7 @@ def merge_files(persona_id: str, output: str | None) -> None:
 
     if output:
         try:
+            ensure_parent_dirs(Path(output))
             with open(output, "w", encoding="utf-8") as f:
                 f.write(merged)
         except OSError as e:


### PR DESCRIPTION
## Summary
- provide `ensure_parent_dirs` helper to create directory trees
- use it before writing merged persona files
- call helper when generating `openapi.json`
- create parent dirs for spawned persona manifests

## Testing
- `pytest -q` *(fails: command not found)*