### PR TITLE
Add Discord bridge

### DIFF
--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -18,3 +18,13 @@ and respond to messages in Discord.
    the bot can see and the result sent back to the same channel.
 
 `bot.py` keeps things minimal so you can adapt it to your needs.
+
+## API Bridge
+
+Forward messages to the REST API instead of a local persona:
+
+```bash
+export DISCORD_BOT_TOKEN=YOUR_TOKEN
+export FRENZY_API_URL=http://localhost:8000
+python bridge.py
+```

--- a/clients/discord/bridge.py
+++ b/clients/discord/bridge.py
@@ -1,0 +1,43 @@
+import asyncio
+import logging
+import os
+
+import aiohttp
+import discord
+
+API_URL = os.getenv("FRENZY_API_URL", "http://localhost:8000").rstrip("/")
+TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Client(intents=intents)
+
+_last = 0.0
+
+async def send(text: str) -> str:
+    global _last
+    wait = 1 - (asyncio.get_event_loop().time() - _last)
+    if wait > 0:
+        await asyncio.sleep(wait)
+    _last = asyncio.get_event_loop().time()
+    async with aiohttp.ClientSession() as s:
+        async with s.post(f"{API_URL}/chat", json={"character": "blueprint-nova", "message": text}) as r:
+            r.raise_for_status()
+            return (await r.json()).get("reply", "")
+
+@client.event
+async def on_message(msg: discord.Message):
+    if msg.author.bot:
+        return
+    try:
+        reply = await send(msg.content)
+    except Exception as exc:  # pragma: no cover - runtime safety
+        log.exception("Bridge error: %s", exc)
+        reply = "Error contacting the API."
+    await msg.channel.send(reply)
+
+client.run(TOKEN)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.30
 openai>=1.14
 redis==5.0
 pyyaml==6.0
+discord.py>=2.4


### PR DESCRIPTION
## Summary
- add `discord.py` to requirements
- implement `clients/discord/bridge.py` that posts to `/chat`
- document the bridge in the Discord README

## Testing
- `pytest -q` *(fails: command not found)*