### PR TITLE
Fix Dockerfile command for compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY . .
-CMD ["uvicorn","api.character_router:app","--host","0.0.0.0","--port","8000"]
+CMD ["uvicorn", "api.character_router:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- use uvicorn to run the FastAPI app

## Testing
- `pytest -q` *(fails: `pytest` not found)*