### PR TITLE
Add pytest config for quieter CI output

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q -s
+testpaths = tests


### PR DESCRIPTION
## Summary
- set pytest to use quiet output and run tests from tests/

## Testing
- `python3 -m pytest -q -s tests` *(fails: No module named pytest)*