### PR TITLE
Add package-style imports for tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -123,7 +123,7 @@ if 'httpx' not in sys.modules:
 
 from fastapi.testclient import TestClient
 import types as _types
-import api.character_router as cr
+from api import character_router as cr
 
 
 def _mock_rate_limit(monkeypatch):

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -1,6 +1,6 @@
 import yaml
 import pytest
-import api.character_router as cr
+from api import character_router as cr
 
 
 def test_manifest_requires_prompt_file(tmp_path, monkeypatch):

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,6 +1,6 @@
 import redis
 from fastapi import HTTPException
-import api.character_router as cr
+from api import character_router as cr
 from api import rate_limit
 
 


### PR DESCRIPTION
## Summary
- ensure tests folder is a package
- use package import form for `api.character_router`

## Testing
- `pytest -q` *(fails: command not found)*