### PR TITLE
Switch to fakeredis when REDIS_URL unset

### DIFF
--- a/fakeredis/__init__.py
+++ b/fakeredis/__init__.py
@@ -1,0 +1,13 @@
+class FakeRedis:
+    """Very small subset of fakeredis.FakeRedis for tests."""
+
+    def __init__(self):
+        self._data = {}
+
+    def incr(self, key):
+        self._data[key] = self._data.get(key, 0) + 1
+        return self._data[key]
+
+    def expire(self, key, ttl):
+        # TTL ignored but kept for interface compatibility
+        pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,8 +127,11 @@ import api.character_router as cr
 
 
 def _mock_rate_limit(monkeypatch):
-    monkeypatch.setattr(cr.r, 'incr', lambda *a, **k: 1)
-    monkeypatch.setattr(cr.r, 'expire', lambda *a, **k: None)
+    fake = types.SimpleNamespace(
+        incr=lambda *a, **k: 1,
+        expire=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(cr, 'get_redis', lambda: fake)
 
 
 def test_manifest_returns_manifest():

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -5,10 +5,14 @@ from api import rate_limit
 
 
 def test_rate_limit_redis_down(monkeypatch):
-    def boom(*args, **kwargs):
-        raise redis.exceptions.ConnectionError
+    class BoomRedis:
+        def incr(self, *args, **kwargs):
+            raise redis.exceptions.ConnectionError
 
-    monkeypatch.setattr(cr.r, "incr", boom)
+        def expire(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(cr, "get_redis", lambda: BoomRedis())
     try:
         rate_limit("1.1.1.1")
     except HTTPException as exc:


### PR DESCRIPTION
## Summary
- add simple fakeredis module with FakeRedis
- return FakeRedis from `get_redis()` when `REDIS_URL` isn't set
- call `get_redis()` inside `rate_limit`
- update tests for new helper

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*