### PR TITLE
Add redis fallback logic

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,6 +124,7 @@ if 'httpx' not in sys.modules:
 from fastapi.testclient import TestClient
 import types as _types
 from api import character_router as cr
+import collections
 
 
 def _mock_rate_limit(monkeypatch):
@@ -131,7 +132,8 @@ def _mock_rate_limit(monkeypatch):
         incr=lambda *a, **k: 1,
         expire=lambda *a, **k: None,
     )
-    monkeypatch.setattr(cr, 'get_redis', lambda: fake)
+    monkeypatch.setattr(cr, 'r', fake)
+    monkeypatch.setattr(cr, '_fallback_counter', collections.Counter())
 
 
 def test_manifest_returns_manifest():


### PR DESCRIPTION
## Summary
- add local redis client and fallback Counter in `character_router`
- update test helpers for new redis implementation
- adapt redis failure test for in-memory fallback

## Testing
- `pytest -q` *(fails: command not found)*