### PR TITLE
Catch missing persona files

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,12 +28,17 @@ def _merge_text(pid: str) -> str:
     _, instr, know = persona
     instr_path = ps.find_file(instr)
     know_path = ps.find_file(know)
-    if not (instr_path and know_path):
-        raise HTTPException(status_code=404, detail="Files missing")
-    with open(instr_path, "r", encoding="utf-8") as f:
-        merged = f.read().rstrip() + "\n\n"
-    with open(know_path, "r", encoding="utf-8") as f:
-        merged += f.read().lstrip()
+    try:
+        merged = (
+            Path(instr_path).read_text()
+            + "\n\n"
+            + Path(know_path).read_text()
+        )
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail="Instruction or knowledge file missing",
+        )
     return merged
 
 

--- a/tests/test_merge_endpoint.py
+++ b/tests/test_merge_endpoint.py
@@ -139,3 +139,29 @@ def test_merge_endpoint_returns_text(monkeypatch, tmp_path):
         resp = client.post("/merge", json=1)
         assert resp.status_code == 200
         assert resp.json() == {"text": "hello\n\nworld"}
+
+
+def test_merge_endpoint_missing_instruction(monkeypatch, tmp_path):
+    know = tmp_path / "knowledge.txt"
+    know.write_text("data")
+
+    monkeypatch.setattr(ps, "PERSONAS", {"1": ("Test", "instruction.txt", "knowledge.txt")})
+    monkeypatch.setattr(ps, "find_file", lambda f: str(tmp_path / f))
+
+    with TestClient(app.app) as client:
+        resp = client.post("/merge", json=1)
+        assert resp.status_code == 404
+        assert resp.json() == {"detail": "Instruction or knowledge file missing"}
+
+
+def test_merge_endpoint_missing_knowledge(monkeypatch, tmp_path):
+    instr = tmp_path / "instruction.txt"
+    instr.write_text("stuff")
+
+    monkeypatch.setattr(ps, "PERSONAS", {"1": ("Test", "instruction.txt", "knowledge.txt")})
+    monkeypatch.setattr(ps, "find_file", lambda f: str(tmp_path / f))
+
+    with TestClient(app.app) as client:
+        resp = client.post("/merge", json=1)
+        assert resp.status_code == 404
+        assert resp.json() == {"detail": "Instruction or knowledge file missing"}


### PR DESCRIPTION
## Summary
- handle missing files when merging persona text
- test /merge error when files vanish

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*