### PR TITLE
Add OpenAPI make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: openapi
+openapi:
+	python scripts/generate_openapi.py > openapi.json
+	git add openapi.json

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+import sys
+import types
+
+import yaml  # Ensure pyyaml is installed
+
+from gptfrenzy.utils import ensure_parent_dirs
+from api.character_router import app as character_app
+from app import app
+
+# Stub optional dependencies that are unnecessary for spec generation
+sys.modules.setdefault(
+    "redis",
+    types.SimpleNamespace(
+        from_url=lambda *a, **kw: types.SimpleNamespace(),
+        exceptions=types.SimpleNamespace(ConnectionError=Exception),
+    ),
+)
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=lambda *a, **kw: object()))
+
+# Mount the character API so the spec includes those routes
+app.include_router(character_app.router)
+
+path = Path("openapi.json")
+ensure_parent_dirs(path)
+with path.open("w", encoding="utf-8") as f:
+    json.dump(app.openapi(), f, indent=2)


### PR DESCRIPTION
## Summary
- add Makefile with `openapi` target to run the generator and stage the spec
- implement `scripts/generate_openapi.py` which imports PyYAML and generates `openapi.json`

## Testing
- `python -m py_compile scripts/generate_openapi.py`
- `make openapi` *(fails: ModuleNotFoundError: No module named 'yaml')*