### PR TITLE
Add rich dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ isort
 pytest
 fakeredis
 pyyaml
+rich~=13.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ uvicorn[standard]~=0.30
 pytest
 fakeredis
 pyyaml
+rich~=13.7

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,1 +1,2 @@
 requests
+rich~=13.7


### PR DESCRIPTION
## Summary
- add `rich` to `requirements.txt`, `requirements-dev.txt`, and `sdk/python/requirements.txt`
- attempt to run `pip-compile` but command not available

## Testing
- `pip-compile requirements.txt --output-file requirements-lock.txt` *(fails: command not found)*