### PR TITLE
Keep OpenAPI spec updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -19,3 +21,9 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run tests
         run: pytest -q
+      - name: Update OpenAPI spec
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          make openapi
+          git push

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: openapi
 openapi:
-	python scripts/generate_openapi.py > openapi.json
+	python app.py --openapi
 	git add openapi.json
+	git diff --cached --quiet openapi.json || git commit -m "Update openapi.json" openapi.json


### PR DESCRIPTION
## Summary
- update `openapi` Makefile target to run `python app.py --openapi`
- add CI step that regenerates and commits `openapi.json`

## Testing
- `pytest -q` *(fails: command not found)*