### PR TITLE
Enforce Python 3.10+ requirement

### DIFF
--- a/gptfrenzy/__init__.py
+++ b/gptfrenzy/__init__.py
@@ -1,1 +1,13 @@
+"""GPT Frenzy package.
+
+Raises a clear error when imported on unsupported Python versions.
+"""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 10):
+    raise RuntimeError("GPT Frenzy requires Python 3.10 or later")
+
 from .spawn import launch, make_manifest

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ version = 0.0.0
 
 [options]
 packages = find:
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## Summary
- enforce minimum Python version when importing package
- set `python_requires` to `>=3.10`

## Testing
- `pytest -q` *(fails: command not found)*