### PR TITLE
Add pytest to dev requirements and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
           cache: 'pip'
       - name: Install dev dependencies
         run: pip install -r requirements-dev.txt --break-system-packages
-      - name: Install dependencies
-        run: pip install -r requirements.txt
       - name: Run tests
         run: pytest -q
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Update OpenAPI spec
         run: |
           git config user.name "github-actions"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,5 @@
+-r requirements.txt
 black
-pytest
-fakeredis
 flake8
 isort
-pytest
-fakeredis
-pyyaml
-rich~=13.7
+pytest~=8.1


### PR DESCRIPTION
## Summary
- ensure dev dependencies include runtime requirements and pytest
- run tests after installing dev dependencies before installing app deps

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement discord.py~=2.4)*
- `pytest -q` *(fails: command not found)*