### PR TITLE
Improve OpenAI client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The API reads a few settings from the environment. When using
 `docker-compose.yml` you can override these values:
 
 - `OPENAI_API_KEY` – your OpenAI authentication key.
-- `OPENAI_MODEL` – OpenAI model name (default: `gpt-4o-mini`).
+- `OPENAI_MODEL` – OpenAI model name (default: `gpt-4o`).
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).
 - `REDIS_PORT` – port for Redis (default: `6379`).

--- a/api/character_router.py
+++ b/api/character_router.py
@@ -14,10 +14,13 @@ import functools
 
 log = logging.getLogger(__name__)
 
-client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+_api_key = os.getenv("OPENAI_API_KEY")
+if not _api_key:
+    raise RuntimeError("OPENAI_API_KEY environment variable not set")
+client = openai.OpenAI(api_key=_api_key)
 # Allow callers to set the OpenAI model via env with a sensible default so we
 # can easily swap models when deploying.
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
 BASE = pathlib.Path(__file__).parent.parent
 PERSONA_DIR = BASE / "personas"
 MANIFEST = BASE / "manifest.yaml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     build: .
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      # Select the OpenAI model used by the API (default: "gpt-4o-mini")
-      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
+      # Select the OpenAI model used by the API (default: "gpt-4o")
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o}
       # Optional Redis connection URL. Overrides host/port if set.
       - REDIS_URL=${REDIS_URL}
       # Hostname of the Redis instance used by the API (default: "redis")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 import collections
+import os
 import pytest
 import fakeredis
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
 from api import character_router as cr
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- require `OPENAI_API_KEY` when creating the OpenAI client
- default to the `gpt-4o` model
- update docs and docker compose examples
- ensure tests set a dummy API key

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*