### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -24,6 +24,9 @@ MANIFEST = BASE / "manifest.yaml"
 PROMPTS = {}
 _redis_client = None
 
+# Friendly message when OpenAI API fails
+OPENAI_ERROR_MSG = "\u26a0\ufe0f Sorry, something went wrong with the language model."
+
 
 def get_redis():
     """Return a Redis client or a fakeredis stub when no REDIS_URL."""
@@ -35,6 +38,7 @@ def get_redis():
         else:
             _redis_client = fakeredis.FakeRedis()
     return _redis_client
+
 
 app = FastAPI(title="GPT Frenzy API")
 
@@ -73,15 +77,11 @@ def _load_manifest():
             raise ValueError(f"Invalid manifest entry at {MANIFEST}:{idx}")
 
         missing = [
-            key
-            for key in ("id", "prompt_file", "entrypoint")
-            if not entry.get(key)
+            key for key in ("id", "prompt_file", "entrypoint") if not entry.get(key)
         ]
         if missing:
             missing_keys = ", ".join(missing)
-            raise ValueError(
-                f"Manifest entry {MANIFEST}:{idx} missing {missing_keys}"
-            )
+            raise ValueError(f"Manifest entry {MANIFEST}:{idx} missing {missing_keys}")
 
         manifest[entry["id"]] = entry
 
@@ -107,6 +107,7 @@ def _prime_prompts():
         except FileNotFoundError as exc:
             log.warning("Prompt file for '%s' missing: %s", pid, exc)
 
+
 _prime_prompts()
 
 
@@ -116,13 +117,18 @@ class Msg(BaseModel):
 
 
 import os, redis, functools
-r = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379"), decode_responses=True)
+
+r = redis.from_url(
+    os.getenv("REDIS_URL", "redis://localhost:6379"), decode_responses=True
+)
 from collections import Counter
+
 _fallback_counter = Counter()
 
 
 def handle_errors(func):
     """Translate common exceptions into HTTP errors."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -171,10 +177,7 @@ def chat(req: Msg, request: Request):
         )
     except Exception as exc:
         log.exception("OpenAI API request failed: %s", exc)
-        raise HTTPException(
-            status_code=502,
-            detail=f"⚠️ Sorry, something went wrong: {exc}"
-        ) from exc
+        raise HTTPException(status_code=500, detail=OPENAI_ERROR_MSG) from exc
     return {"reply": reply}
 
 
@@ -201,10 +204,7 @@ def chat_stream(req: Msg, request: Request):
                     yield f"data: {token}\n\n"
         except Exception as exc:
             log.exception("OpenAI API request failed: %s", exc)
-            raise HTTPException(
-                status_code=502,
-                detail=f"⚠️ Sorry, something went wrong: {exc}"
-            ) from exc
+            raise HTTPException(status_code=500, detail=OPENAI_ERROR_MSG) from exc
 
     return StreamingResponse(gen(), media_type="text/event-stream")
 
@@ -243,9 +243,17 @@ def merge(req: MergeRequest):
     instr = next(persona_dir.glob("*_GPT_INSTRUCTIONS.txt"), None)
     know = next(persona_dir.glob("*_DEEP_KNOWLEDGE_*.txt"), None)
     if not instr or not know:
-        raise HTTPException(status_code=422, detail="Instruction or knowledge file missing")
+        raise HTTPException(
+            status_code=422, detail="Instruction or knowledge file missing"
+        )
     try:
-        merged = instr.read_text(encoding="utf-8").rstrip() + "\n\n" + know.read_text(encoding="utf-8").lstrip()
+        merged = (
+            instr.read_text(encoding="utf-8").rstrip()
+            + "\n\n"
+            + know.read_text(encoding="utf-8").lstrip()
+        )
     except FileNotFoundError:
-        raise HTTPException(status_code=422, detail="Instruction or knowledge file missing")
+        raise HTTPException(
+            status_code=422, detail="Instruction or knowledge file missing"
+        )
     return {"merged": merged}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,32 +3,32 @@ import types
 import json
 
 # Minimal httpx stub so FastAPI's TestClient can run without dependency.
-if 'httpx' not in sys.modules:
-    httpx = types.ModuleType('httpx')
+if "httpx" not in sys.modules:
+    httpx = types.ModuleType("httpx")
 
     class URL:
         def __init__(self, url: str):
-            if '://' in url:
-                self.scheme, rest = url.split('://', 1)
+            if "://" in url:
+                self.scheme, rest = url.split("://", 1)
             else:
-                self.scheme, rest = 'http', url
-            if '/' in rest:
-                netloc, path_query = rest.split('/', 1)
-                path_query = '/' + path_query
+                self.scheme, rest = "http", url
+            if "/" in rest:
+                netloc, path_query = rest.split("/", 1)
+                path_query = "/" + path_query
             else:
                 netloc = rest
-                path_query = '/'
-            if '?' in path_query:
-                path, query = path_query.split('?', 1)
+                path_query = "/"
+            if "?" in path_query:
+                path, query = path_query.split("?", 1)
             else:
-                path, query = path_query, ''
+                path, query = path_query, ""
             self.netloc = netloc.encode()
             self.path = path
             self.raw_path = path.encode()
             self.query = query.encode()
 
     class Request:
-        def __init__(self, method: str, url: str, headers=None, content: bytes = b''):
+        def __init__(self, method: str, url: str, headers=None, content: bytes = b""):
             self.method = method
             self.url = URL(url)
             self.headers = headers or {}
@@ -48,10 +48,10 @@ if 'httpx' not in sys.modules:
         def __init__(self, status_code=200, headers=None, stream=None, request=None):
             self.status_code = status_code
             self.headers = {k: v for k, v in (headers or [])}
-            if hasattr(stream, 'read'):
+            if hasattr(stream, "read"):
                 self._content = stream.read()
             else:
-                self._content = stream or b''
+                self._content = stream or b""
             self.request = request
 
         @property
@@ -65,31 +65,42 @@ if 'httpx' not in sys.modules:
         pass
 
     class Client:
-        def __init__(self, *, app=None, base_url='', headers=None, transport=None, follow_redirects=True, cookies=None):
+        def __init__(
+            self,
+            *,
+            app=None,
+            base_url="",
+            headers=None,
+            transport=None,
+            follow_redirects=True,
+            cookies=None
+        ):
             self.base_url = base_url
             self.headers = headers or {}
             self._transport = transport
 
-        def request(self, method, url, *, content=None, json=None, headers=None, **kwargs):
-            if not url.startswith('http'):
-                url = self.base_url.rstrip('/') + url
+        def request(
+            self, method, url, *, content=None, json=None, headers=None, **kwargs
+        ):
+            if not url.startswith("http"):
+                url = self.base_url.rstrip("/") + url
             hdrs = self.headers.copy()
             if headers:
                 hdrs.update(headers)
             if json is not None:
-                content = __import__('json').dumps(json).encode()
-                hdrs.setdefault('content-type', 'application/json')
+                content = __import__("json").dumps(json).encode()
+                hdrs.setdefault("content-type", "application/json")
             if isinstance(content, str):
                 content = content.encode()
-            content = content or b''
+            content = content or b""
             req = Request(method, url, hdrs, content)
             return self._transport.handle_request(req)
 
         def get(self, url, **kw):
-            return self.request('GET', url, **kw)
+            return self.request("GET", url, **kw)
 
         def post(self, url, **kw):
-            return self.request('POST', url, **kw)
+            return self.request("POST", url, **kw)
 
         def __enter__(self):
             return self
@@ -119,15 +130,16 @@ if 'httpx' not in sys.modules:
         AuthTypes=object,
         TimeoutTypes=object,
     )
-    sys.modules['httpx'] = httpx
+    sys.modules["httpx"] = httpx
 
 from fastapi.testclient import TestClient
 import types as _types
 from api import character_router as cr
 
+
 def test_manifest_returns_manifest():
     with TestClient(cr.app) as client:
-        resp = client.get('/manifest')
+        resp = client.get("/manifest")
         assert resp.status_code == 200
         assert resp.json() == cr._load_manifest()
 
@@ -135,35 +147,41 @@ def test_manifest_returns_manifest():
 def test_chat(monkeypatch):
 
     class Choice:
-        message = _types.SimpleNamespace(content='hi')
+        message = _types.SimpleNamespace(content="hi")
 
     def fake_create(*args, **kwargs):
         return _types.SimpleNamespace(choices=[Choice()])
 
-    monkeypatch.setattr(cr.client.chat.completions, 'create', fake_create)
+    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
     with TestClient(cr.app) as client:
-        resp = client.post('/chat', json={'character': 'blueprint-nova', 'message': 'hey'})
+        resp = client.post(
+            "/chat", json={"character": "blueprint-nova", "message": "hey"}
+        )
         assert resp.status_code == 200
-        assert resp.json() == {'reply': 'hi'}
+        assert resp.json() == {"reply": "hi"}
 
 
 def test_chat_stream(monkeypatch):
 
     def fake_create(*args, **kwargs):
-        assert kwargs.get('stream') is True
+        assert kwargs.get("stream") is True
 
         class Chunk:
             def __init__(self, c: str):
-                self.choices = [_types.SimpleNamespace(delta=_types.SimpleNamespace(content=c))]
+                self.choices = [
+                    _types.SimpleNamespace(delta=_types.SimpleNamespace(content=c))
+                ]
 
-        return [Chunk('A'), Chunk('B')]
+        return [Chunk("A"), Chunk("B")]
 
-    monkeypatch.setattr(cr.client.chat.completions, 'create', fake_create)
+    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
     with TestClient(cr.app) as client:
-        resp = client.post('/chat/stream', json={'character': 'blueprint-nova', 'message': 'hey'})
+        resp = client.post(
+            "/chat/stream", json={"character": "blueprint-nova", "message": "hey"}
+        )
         assert resp.status_code == 200
-        assert resp.headers['content-type'].startswith('text/event-stream')
-        assert resp.text == 'data: A\n\ndata: B\n\n'
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert resp.text == "data: A\n\ndata: B\n\n"
 
 
 def test_chat_unknown_persona(monkeypatch):
@@ -171,11 +189,11 @@ def test_chat_unknown_persona(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(cr.client.chat.completions, 'create', boom)
+    monkeypatch.setattr(cr.client.chat.completions, "create", boom)
     with TestClient(cr.app) as client:
-        resp = client.post('/chat', json={'character': 'bogus', 'message': 'hi'})
+        resp = client.post("/chat", json={"character": "bogus", "message": "hi"})
         assert resp.status_code == 404
-        assert resp.json() == {'detail': 'Persona not found'}
+        assert resp.json() == {"detail": "Persona not found"}
 
 
 def test_chat_stream_unknown_persona(monkeypatch):
@@ -183,11 +201,11 @@ def test_chat_stream_unknown_persona(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(cr.client.chat.completions, 'create', boom)
+    monkeypatch.setattr(cr.client.chat.completions, "create", boom)
     with TestClient(cr.app) as client:
-        resp = client.post('/chat/stream', json={'character': 'bogus', 'message': 'hi'})
+        resp = client.post("/chat/stream", json={"character": "bogus", "message": "hi"})
         assert resp.status_code == 404
-        assert resp.json() == {'detail': 'Persona not found'}
+        assert resp.json() == {"detail": "Persona not found"}
 
 
 def test_chat_openai_error(monkeypatch):
@@ -195,11 +213,13 @@ def test_chat_openai_error(monkeypatch):
     def fake_create(*args, **kwargs):
         raise RuntimeError("bad boom")
 
-    monkeypatch.setattr(cr.client.chat.completions, 'create', fake_create)
+    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
     with TestClient(cr.app) as client:
-        resp = client.post('/chat', json={'character': 'blueprint-nova', 'message': 'hi'})
-        assert resp.status_code == 502
-        assert 'bad boom' in resp.json()['detail']
+        resp = client.post(
+            "/chat", json={"character": "blueprint-nova", "message": "hi"}
+        )
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == cr.OPENAI_ERROR_MSG
 
 
 def test_chat_stream_openai_error(monkeypatch):
@@ -207,9 +227,10 @@ def test_chat_stream_openai_error(monkeypatch):
     def fake_create(*args, **kwargs):
         raise RuntimeError("kaboom")
 
-    monkeypatch.setattr(cr.client.chat.completions, 'create', fake_create)
+    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
     with TestClient(cr.app) as client:
-        resp = client.post('/chat/stream', json={'character': 'blueprint-nova', 'message': 'hi'})
-        assert resp.status_code == 502
-        assert 'kaboom' in resp.json()['detail']
-
+        resp = client.post(
+            "/chat/stream", json={"character": "blueprint-nova", "message": "hi"}
+        )
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == cr.OPENAI_ERROR_MSG


### PR DESCRIPTION
## Summary
- add friendly OpenAI error message
- return HTTP 500 for failed OpenAI calls
- test updated for new error handling

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*