### PR TITLE
Add OpenAPI sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,5 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run tests
         run: pytest -q
-      - name: Update OpenAPI spec
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          make openapi
-          git push
+      - name: Check OpenAPI spec
+        run: make openapi-check

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: openapi
 openapi:
-	python app.py --openapi
-	git add openapi.json
-	git diff --cached --quiet openapi.json || git commit -m "Update openapi.json" openapi.json
+	PYTHONPATH=. python scripts/generate_openapi.py openapi.json
+
+.PHONY: openapi-check
+openapi-check:
+	@temp_file=$$(mktemp); \
+	PYTHONPATH=. python scripts/generate_openapi.py $$temp_file; \
+	diff -u openapi.json $$temp_file; \
+	rm $$temp_file

--- a/openapi.json
+++ b/openapi.json
@@ -25,14 +25,13 @@
     "/merge": {
       "post": {
         "summary": "Merge",
-        "description": "Return merged instruction and knowledge text.",
+        "description": "Return merged instruction and knowledge text for persona ``id``.",
         "operationId": "merge_merge_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "title": "Id",
-                "type": "integer"
+                "$ref": "#/components/schemas/MergeRequest"
               }
             }
           },
@@ -196,6 +195,19 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             }
+          }
+        }
+      },
+      "MergeRequest": {
+        "title": "MergeRequest",
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
           }
         }
       },

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -3,11 +3,11 @@ from pathlib import Path
 import sys
 import types
 
-import yaml  # Ensure pyyaml is installed
-
-from gptfrenzy.utils import ensure_parent_dirs
-from api.character_router import app as character_app
-from app import app
+try:
+    import yaml  # Ensure pyyaml is installed
+except Exception:
+    yaml = types.SimpleNamespace(safe_load=lambda *_args, **_kw: [])
+    sys.modules.setdefault("yaml", yaml)
 
 # Stub optional dependencies that are unnecessary for spec generation
 sys.modules.setdefault(
@@ -19,10 +19,31 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=lambda *a, **kw: object()))
 
+from gptfrenzy.utils import ensure_parent_dirs
+from api.character_router import app as character_app
+from app import app
+
+
 # Mount the character API so the spec includes those routes
 app.include_router(character_app.router)
 
-path = Path("openapi.json")
-ensure_parent_dirs(path)
-with path.open("w", encoding="utf-8") as f:
-    json.dump(app.openapi(), f, indent=2)
+
+def generate(path: Path) -> None:
+    """Write the OpenAPI spec to *path*."""
+    ensure_parent_dirs(path)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(app.openapi(), f, indent=2)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for CLI usage."""
+    argv = argv or sys.argv[1:]
+    if argv:
+        path = Path(argv[0])
+    else:
+        path = Path("openapi.json")
+    generate(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_openapi_sync.py
+++ b/tests/test_openapi_sync.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+from scripts import generate_openapi
+
+
+def test_openapi_json_is_up_to_date(tmp_path):
+    temp = tmp_path / "openapi.json"
+    generate_openapi.generate(temp)
+
+    generated = json.loads(temp.read_text())
+    existing = json.loads(Path("openapi.json").read_text())
+
+    assert generated == existing, "openapi.json is out of date, run `make openapi`"


### PR DESCRIPTION
## Summary
- add `openapi` and `openapi-check` Makefile targets
- add workflow step to verify `openapi.json`
- regenerate `openapi.json`
- expose a helper in `generate_openapi.py`
- add regression test ensuring OpenAPI spec is current

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `make openapi-check`