### PR TITLE
Improve CI and Redis fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=sk-your-key
+OPENAI_MODEL=gpt-4o

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,14 @@ jobs:
         run: pip install -r requirements-dev.txt --break-system-packages
       - name: Run tests
         run: pytest -q
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-      - name: Update OpenAPI spec
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          make openapi
-          git push
+
+  openapi-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt --break-system-packages
+      - run: make openapi
+      - run: git diff --exit-code openapi.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,13 @@ python3 -m pytest
 ```
 
 All tests live in the `tests/` directory.
+
+### Updating the API spec
+
+If you change any API routes, regenerate `openapi.json` and commit the result:
+
+```bash
+make openapi && git add openapi.json
+```
+
+The CI workflow checks that this file is up to date.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
 .PHONY: openapi
 openapi:
-	python app.py --openapi
-	git add openapi.json
-	git diff --cached --quiet openapi.json || git commit -m "Update openapi.json" openapi.json
+    python app.py --openapi

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ curl -X POST http://localhost:8000/merge \
 
 ### Environment Variables
 
-The API reads a few settings from the environment. When using
-`docker-compose.yml` you can override these values:
+The API reads a few settings from the environment. Copy `.env.example` to `.env`
+and edit the values, or override them in `docker-compose.yml`:
 
 - `OPENAI_API_KEY` – your OpenAI authentication key.
 - `OPENAI_MODEL` – OpenAI model name (default: `gpt-4o`).
@@ -191,6 +191,9 @@ python3 create_your_own_gpt.py
 > **Note**: The mini-game lives in its own folder and is not integrated with the
 > main GPT Frenzy app yet. It's an optional side project that may change or break
 > without notice.
+
+The `mini-game/` folder is **experimental**. See
+[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) for how the repository is laid out.
 
 ## Mini-game
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   api:
     build: .
+    env_file: .env
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       # Select the OpenAI model used by the API (default: "gpt-4o")
@@ -16,3 +17,5 @@ services:
     ports: ["8000:8000"]
   redis:
     image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/openapi.json
+++ b/openapi.json
@@ -25,14 +25,13 @@
     "/merge": {
       "post": {
         "summary": "Merge",
-        "description": "Return merged instruction and knowledge text.",
+        "description": "Return merged instruction and knowledge text for persona ``id``.",
         "operationId": "merge_merge_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "title": "Id",
-                "type": "integer"
+                "$ref": "#/components/schemas/MergeRequest"
               }
             }
           },
@@ -196,6 +195,19 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             }
+          }
+        }
+      },
+      "MergeRequest": {
+        "title": "MergeRequest",
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
           }
         }
       },

--- a/tests/test_redis_fallback_integration.py
+++ b/tests/test_redis_fallback_integration.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+import types
+from fastapi.testclient import TestClient
+import pytest
+
+
+# override the autouse fake_redis fixture
+@pytest.fixture(autouse=True)
+def fake_redis():
+    pass
+
+
+def test_fallback_to_fakeredis(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://does-not-exist")
+    sys.modules.setdefault(
+        "openai", types.SimpleNamespace(OpenAI=lambda *a, **kw: object())
+    )
+    import api.character_router as cr
+
+    importlib.reload(cr)
+    with TestClient(cr.app) as client:
+        resp = client.get("/")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add Redis service to docker-compose and env file example
- expose repo layout and mark mini-game as experimental
- update API environment variable docs
- stubbed redis fallback in `character_router`
- add openapi-check workflow and update contribution guide
- regenerate OpenAPI spec
- add integration test for Redis fallback

## Testing
- `pytest -q` *(fails: command not found)*