### PR TITLE
Update CI matrix and skip integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,16 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Install dev dependencies
         run: pip install -r requirements-dev.txt --break-system-packages

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
-addopts = -q -s
+addopts = -s -m "not integration"
 testpaths = tests
+markers =
+    integration: tests that require network access


### PR DESCRIPTION
## Summary
- extend Python test matrix with 3.10 & 3.11
- skip integration tests by default

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement)*
- `pytest -q` *(fails: command not found)*