### PR TITLE
Add placeholder lockfile and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt --break-system-packages
+      - name: Install dependencies
+        run: pip install --no-cache-dir --require-hashes -r requirements-lock.txt --break-system-packages
       - name: Run tests
         run: pytest -q
 

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,17 @@
+# WARNING: Placeholder lock file.
+# TODO: Generate with 'pip-compile' to pin exact versions and hashes.
+discord.py==2.4.0
+fastapi==0.110.0
+httpx==0.27.0
+openai==1.14.0
+pydantic==2.7.0
+pytest-asyncio==0.23.0
+pytest==8.1.0
+pyyaml==6.0
+redis==5.0.0
+uvicorn[standard]==0.30.0
+black
+flake8
+isort
+fakeredis
+rich==13.7.0


### PR DESCRIPTION
## Summary
- add a placeholder `requirements-lock.txt`
- update `ci.yml` to install from the lock file with `--require-hashes`

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement discord.py)*
- `pytest -q` *(fails: command not found)*