### PR TITLE
Add fakeredis.StrictRedis fallback

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -32,7 +32,7 @@ OPENAI_ERROR_MSG = "\u26a0\ufe0f Sorry, something went wrong with the language m
 
 
 def get_redis():
-    """Return a Redis client or a fakeredis stub when no REDIS_URL."""
+    """Return a Redis client, falling back to :class:`fakeredis.StrictRedis`."""
     global _redis_client
     if _redis_client is None:
         redis_url = os.getenv("REDIS_URL")
@@ -42,9 +42,9 @@ def get_redis():
                 client.ping()
                 _redis_client = client
             except redis.RedisError:
-                _redis_client = fakeredis.FakeRedis()
+                _redis_client = fakeredis.StrictRedis()
         else:
-            _redis_client = fakeredis.FakeRedis()
+            _redis_client = fakeredis.StrictRedis()
     return _redis_client
 
 
@@ -159,7 +159,7 @@ def rate_limit(ip, limit=60):
     except redis.RedisError:
         # Switch to in-memory fallback when Redis is unreachable
         global _redis_client
-        _redis_client = fakeredis.FakeRedis()
+        _redis_client = fakeredis.StrictRedis()
         r = _redis_client
         count = r.incr(key)
     if count > limit:

--- a/fakeredis/__init__.py
+++ b/fakeredis/__init__.py
@@ -11,3 +11,8 @@ class FakeRedis:
     def expire(self, key, ttl):
         # TTL ignored but kept for interface compatibility
         pass
+
+
+class StrictRedis(FakeRedis):
+    """Alias of FakeRedis used as a drop-in stand-in for fakeredis.StrictRedis."""
+    pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ black
 flake8
 isort
 pytest~=8.1
+fakeredis==2.*


### PR DESCRIPTION
## Summary
- use fakeredis.StrictRedis for Redis fallback
- make StrictRedis alias in local fakeredis stub
- depend on fakeredis 2.x for dev installs

## Testing
- `pytest -q` *(fails: command not found)*