### PR TITLE
Add openapi generation check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,7 @@ jobs:
         run: pip install -r requirements-dev.txt --break-system-packages
       - name: Run tests
         run: pytest -q
-
-  openapi-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - run: pip install -r requirements.txt --break-system-packages
-      - run: make openapi
-      - run: git diff --exit-code openapi.json
+      - name: Generate OpenAPI spec
+        run: make openapi
+      - name: Fail on OpenAPI diff
+        run: git diff --exit-code openapi.json

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: openapi
 openapi:
-    python app.py --openapi
+	python scripts/generate_openapi.py


### PR DESCRIPTION
## Summary
- switch the `openapi` Makefile target to generate using our helper script
- run `make openapi` in CI after tests and fail if the spec changed

## Testing
- `pytest -q` *(fails: command not found)*
- `make openapi` *(fails: ModuleNotFoundError: No module named 'yaml')*