### PR TITLE
Fix OpenAI model default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 OPENAI_API_KEY=sk-your-key
-OPENAI_MODEL=gpt-4o
+OPENAI_MODEL=gpt-4

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The API reads a few settings from the environment. Copy `.env.example` to `.env`
 and edit the values, or override them in `docker-compose.yml`:
 
 - `OPENAI_API_KEY` – your OpenAI authentication key.
-- `OPENAI_MODEL` – OpenAI model name (default: `gpt-4o`).
+- `OPENAI_MODEL` – OpenAI model name (default: `gpt-4`).
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).
 - `REDIS_PORT` – port for Redis (default: `6379`).

--- a/api/character_router.py
+++ b/api/character_router.py
@@ -20,7 +20,7 @@ if not _api_key:
 client = openai.OpenAI(api_key=_api_key)
 # Allow callers to set the OpenAI model via env with a sensible default so we
 # can easily swap models when deploying.
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4")
 BASE = pathlib.Path(__file__).parent.parent
 PERSONA_DIR = BASE / "personas"
 MANIFEST = BASE / "manifest.yaml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     env_file: .env
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      # Select the OpenAI model used by the API (default: "gpt-4o")
-      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o}
+      # Select the OpenAI model used by the API (default: "gpt-4")
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4}
       # Optional Redis connection URL. Overrides host/port if set.
       - REDIS_URL=${REDIS_URL}
       # Hostname of the Redis instance used by the API (default: "redis")


### PR DESCRIPTION
## Summary
- point OPENAI_MODEL defaults to `gpt-4`
- document new model default in README and docker-compose
- update example environment file

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version)*
- `pytest` *(fails: command not found)*