### PR TITLE
Serve mini-game from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ python3 create_your_own_gpt.py
 
 > **Note**: The mini-game lives in its own folder and is not integrated with the
 > main GPT Frenzy app yet. It's an optional side project that may change or break
-> without notice.
+> without notice. When running the API locally, you can access it at
+> `http://localhost:8000/mini-game`.
 
 The `mini-game/` folder is **experimental**. See
 [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) for how the repository is laid out.

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from fastapi import Body, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 import persona_selector as ps
 from gptfrenzy.core.utils import ensure_parent_dirs
 
@@ -13,6 +14,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Serve the experimental mini-game as static files if present.
+mini_game_dir = Path(__file__).resolve().parent / "mini-game"
+if mini_game_dir.is_dir():
+    app.mount("/mini-game", StaticFiles(directory=str(mini_game_dir), html=True), name="mini-game")
 
 
 @app.get("/personas")

--- a/clients/web/chat_widget.html
+++ b/clients/web/chat_widget.html
@@ -1,6 +1,7 @@
 <!doctype html><meta charset=utf-8><title>GPT Frenzy Chat</title>
 <select id=c></select><br><textarea id=m rows=3 cols=60></textarea>
 <button onclick="s()">Send</button><pre id=o></pre>
+<p><a href="https://github.com/BP-H/code/tree/main/mini-game" target="_blank">Mini-game instructions</a> (separate demo)</p>
 <script>
 const select = document.getElementById('c');
 const msg = document.getElementById('m');


### PR DESCRIPTION
## Summary
- expose `mini-game/` directory via FastAPI StaticFiles
- link to mini-game docs from the web chat widget
- document new `/mini-game` path in README

## Testing
- `pytest -q` *(fails: command not found)*
- `make openapi` *(fails: ModuleNotFoundError: No module named 'yaml')*