### PR TITLE
Handle missing personas gracefully

### DIFF
--- a/api/persona_router.py
+++ b/api/persona_router.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, HTTPException, Body
+from pathlib import Path
+import persona_selector as ps
+
+app = FastAPI(title="Persona Merge API")
+
+@app.post("/merge_persona")
+def merge_persona(id: int = Body(...)):
+    """Return merged instruction and knowledge text for persona ``id``."""
+    persona = ps.PERSONAS.get(str(id))
+    if not persona:
+        raise HTTPException(status_code=404, detail="Persona not found – check ID or path")
+    _, instr, know = persona
+    instr_path = ps.find_file(instr)
+    know_path = ps.find_file(know)
+    if not instr_path or not know_path:
+        raise HTTPException(status_code=404, detail="Persona not found – check ID or path")
+    try:
+        merged = (
+            Path(instr_path).read_text(encoding="utf-8").rstrip()
+            + "\n\n"
+            + Path(know_path).read_text(encoding="utf-8").lstrip()
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Persona not found – check ID or path") from exc
+    return {"text": merged}

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from api import persona_router as pr
+import persona_selector as ps
+
+
+def test_merge_persona_404(monkeypatch):
+    monkeypatch.setattr(ps, "PERSONAS", {})
+    with TestClient(pr.app) as client:
+        resp = client.post("/merge_persona", json={"id": 999})
+        assert resp.status_code == 404
+        assert resp.json() == {"detail": "Persona not found – check ID or path"}
+


### PR DESCRIPTION
## Summary
- add a minimal `persona_router` with `/merge_persona` endpoint
- raise HTTP 404 when persona files are missing
- test 404 response for missing persona

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*