### PR TITLE
Add discord bot using /chat/stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
-.PHONY: openapi
+.PHONY: openapi discord-run
 openapi:
-	python scripts/generate_openapi.py
+        python scripts/generate_openapi.py
+
+discord-run:
+        python clients/discord/bot.py

--- a/README.md
+++ b/README.md
@@ -284,4 +284,5 @@ Grab the stubs in **`/sdk`** and call `/chat`, `/manifest` (JSON), or `/manifest
 
 For details on how the `manifest.yaml` file powers the character system and how to add your own entries, see [docs/manifest_system.md](docs/manifest_system.md).
 To deploy a persona directory in another host (Discord, Unreal, Unity), follow the steps in [docs/spawn_system.md](docs/spawn_system.md).
+For running a Discord bot with the REST API, see [docs/discord_setup.md](docs/discord_setup.md).
 For a Unity-specific C# example using `GptFrenzyClient`, see [docs/unity_integration.md](docs/unity_integration.md).

--- a/docs/discord_setup.md
+++ b/docs/discord_setup.md
@@ -1,0 +1,19 @@
+# Discord Bot Quick Start
+
+This repository includes a simple Discord bot that forwards messages to the GPT Frenzy API.
+
+1. Copy `.env.example` to `.env` and set your credentials:
+   ```
+   DISCORD_TOKEN=your_bot_token
+   FRENZY_API_URL=http://localhost:8000
+   ```
+2. Install the requirements:
+   ```bash
+   python3 -m pip install -r requirements.txt
+   ```
+3. Run the bot with Make:
+   ```bash
+   make discord-run
+   ```
+
+The script loads the `.env` file automatically thanks to `python-dotenv`. Each message is sent to `/chat/stream` and the reply is posted back to the channel.

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -15,3 +15,4 @@ flake8
 isort
 fakeredis
 rich==13.7.0
+python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pytest~=8.1
 pyyaml~=6.0
 redis~=5.0
 uvicorn[standard]~=0.30
+python-dotenv~=1.0
 pytest
 fakeredis
 pyyaml


### PR DESCRIPTION
## Summary
- add python-dotenv to load environment variables
- create discord bot that forwards to the `/chat/stream` API
- document simple discord bot usage
- add `discord-run` target to Makefile
- link new instructions from README

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest')*