### PR TITLE
Add Discord streaming bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
-.PHONY: openapi
+.PHONY: openapi discord-run
 openapi:
 	python scripts/generate_openapi.py
+
+discord-run:
+	python clients/discord/bot.py

--- a/README.md
+++ b/README.md
@@ -285,3 +285,4 @@ Grab the stubs in **`/sdk`** and call `/chat`, `/manifest` (JSON), or `/manifest
 For details on how the `manifest.yaml` file powers the character system and how to add your own entries, see [docs/manifest_system.md](docs/manifest_system.md).
 To deploy a persona directory in another host (Discord, Unreal, Unity), follow the steps in [docs/spawn_system.md](docs/spawn_system.md).
 For a Unity-specific C# example using `GptFrenzyClient`, see [docs/unity_integration.md](docs/unity_integration.md).
+For a quick Discord bot setup, see [docs/discord_setup.md](docs/discord_setup.md).

--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -1,49 +1,71 @@
-"""Minimal Discord bot using the spawn system."""
+"""Discord bot that streams replies from the API."""
 
 import asyncio
 import logging
-import sys
+import os
 
-try:
-    import discord
-except ImportError:  # pragma: no cover - optional dependency
-    print("Install discord.py (`pip install discord.py`) to use this bot")
-    raise SystemExit(1)
+import aiohttp
+import discord
+from dotenv import load_dotenv
 
-from gptfrenzy.core.spawn import launch
 
+load_dotenv()
+
+API_URL = os.getenv("FRENZY_API_URL", "http://localhost:8000").rstrip("/")
+TOKEN = os.getenv("DISCORD_TOKEN")
+CHARACTER = os.getenv("FRENZY_CHARACTER", "blueprint-nova")
+
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Client(intents=intents)
 
-async def main(persona_dir: str, token: str) -> None:
-    persona = launch("discord", persona_dir)
-    intents = discord.Intents.default()
-    intents.message_content = True
-    client = discord.Client(intents=intents)
+_last = 0.0
 
-    @client.event
-    async def on_message(message: discord.Message) -> None:
-        if message.author.bot:
-            return
-        try:
-            reply = await persona.generate(message.content)
-            await message.channel.send(reply)
-        except Exception as exc:  # pragma: no cover - runtime safety
-            log.exception("Failed to handle message: %s", exc)
-            try:
-                await message.channel.send("⚠️ Sorry, something went wrong")
-            except Exception as send_exc:  # pragma: no cover - logging only
-                log.exception("Failed to send error message: %s", send_exc)
 
+async def send_stream(text: str) -> str:
+    """Return a full reply by streaming tokens from the API."""
+    global _last
+    wait = 1 - (asyncio.get_event_loop().time() - _last)
+    if wait > 0:
+        await asyncio.sleep(wait)
+    _last = asyncio.get_event_loop().time()
+    async with aiohttp.ClientSession() as s:
+        async with s.post(
+            f"{API_URL}/chat/stream",
+            json={"character": CHARACTER, "message": text},
+        ) as r:
+            r.raise_for_status()
+            buf = ""
+            reply_parts: list[str] = []
+            async for chunk in r.content.iter_chunked(1024):
+                buf += chunk.decode("utf-8")
+                while "\n\n" in buf:
+                    line, buf = buf.split("\n\n", 1)
+                    if line.startswith("data: "):
+                        reply_parts.append(line[6:])
+            if buf.startswith("data: "):
+                reply_parts.append(buf[6:])
+            return "".join(reply_parts)
+
+
+@client.event
+async def on_message(msg: discord.Message) -> None:
+    if msg.author.bot:
+        return
     try:
-        await client.start(token)
-    except discord.LoginFailure:
-        log.error("Invalid Discord token")
-        raise SystemExit(1)
+        reply = await send_stream(msg.content)
+    except Exception as exc:  # pragma: no cover - runtime safety
+        log.exception("Bridge error: %s", exc)
+        reply = "Error contacting the API."
+    await msg.channel.send(reply)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("Usage: python bot.py <persona_dir> <discord_token>")
+    if not TOKEN:
+        print("DISCORD_TOKEN environment variable not set")
         raise SystemExit(1)
-    asyncio.run(main(sys.argv[1], sys.argv[2]))
+    client.run(TOKEN)
+

--- a/docs/discord_setup.md
+++ b/docs/discord_setup.md
@@ -1,0 +1,16 @@
+# Discord Bot Quick Setup
+
+This project includes a small Discord bot that forwards every message to the
+API's `/chat/stream` endpoint. The bot reads environment variables from a local
+`.env` file using **python-dotenv**.
+
+1. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` to your bot token.
+   Adjust `FRENZY_API_URL` if your server runs on a different host.
+2. Run the bot:
+   ```bash
+   make discord-run
+   ```
+
+The command above loads the `.env` file automatically and starts the bot.  It
+will listen to messages it can see and send the streamed reply back to the same
+channel.

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -14,3 +14,4 @@ flake8
 isort
 fakeredis==2.23.2
 rich==13.7.0
+python-dotenv==1.0.1

--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,4 @@ pyyaml~=6.0
 redis~=5.0
 uvicorn[standard]~=0.30
 rich~=13.7
+python-dotenv~=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml==6.0
 redis==5.0.0
 uvicorn[standard]==0.30.0
 rich==13.7.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add discord bot that streams messages from the API
- add python-dotenv dependency
- provide single-command setup docs
- expose discord-run target in Makefile
- link new docs from README

## Testing
- `pytest -q` *(fails: command not found)*