### PR TITLE
Add environment fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ curl -X POST http://localhost:8000/merge \
 The API reads a few settings from the environment. Copy `.env.example` to `.env`
 and edit the values, or override them in `docker-compose.yml`:
 
-- `OPENAI_API_KEY` – your OpenAI authentication key.
+- `OPENAI_API_KEY` – your OpenAI authentication key. If omitted, the chat
+  endpoints respond with `503` until a key is supplied and a warning is logged at startup.
 - `OPENAI_MODEL` – OpenAI model name (default: `gpt-4`).
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).
 - `REDIS_PORT` – port for Redis (default: `6379`).
 - `USE_FAKE_REDIS` – set to any value to force an in-memory Redis instance.
+  The API also automatically falls back to in-memory Redis if the configured
+  server can't be reached.
 - `ALLOWED_ORIGINS` – comma-separated list for CORS (default: `*`).
 
 ### Updating `openapi.json`

--- a/tests/test_missing_api_key.py
+++ b/tests/test_missing_api_key.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+import types
+from fastapi.testclient import TestClient
+import pytest
+
+
+def test_missing_openai_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # stub openai.OpenAI so we can detect if it's called
+    called = False
+
+    def fail(*a, **kw):
+        nonlocal called
+        called = True
+        raise AssertionError("OpenAI should not be called")
+
+    sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=fail))
+
+    import api.character_router as cr
+    importlib.reload(cr)
+
+    assert cr.client is None
+
+    with TestClient(cr.app) as client:
+        resp = client.get("/")
+        assert resp.status_code == 200
+        resp = client.post(
+            "/chat", json={"character": "blueprint-nova", "message": "hi"}
+        )
+        assert resp.status_code == 503
+        assert "OpenAI API key" in resp.json()["detail"]
+
+    assert called is False


### PR DESCRIPTION
## Summary
- start API even if `OPENAI_API_KEY` is missing
- warn and disable OpenAI usage when API key is absent
- log Redis connection attempts and fallback to fakeredis when needed
- document new behaviour
- test missing API key behaviour

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*