### PR TITLE
Implement streaming Discord bot bridge

### DIFF
--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -28,3 +28,8 @@ export DISCORD_BOT_TOKEN=YOUR_TOKEN
 export FRENZY_API_URL=http://localhost:8000
 python bridge.py
 ```
+
+`bridge.py` reacts only when a user mentions the bot or starts a message with
+`!gpt`. It forwards the remaining text to the API's `/chat/stream` endpoint and
+posts the streamed reply back to the same channel. Any connection errors are
+logged and reported in Discord instead of crashing the bot.


### PR DESCRIPTION
## Summary
- add trigger-based streaming logic in `clients/discord/bridge.py`
- document usage of the bridge bot in the Discord README

## Testing
- `black clients/discord/bridge.py`
- `pytest -q` *(fails: command not found)*