### PR TITLE
Add CI openapi check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         run: pytest -q
       - name: Verify OpenAPI spec
-        run: make check-openapi
+        run: make openapi-check
       - name: Check requirements drift
         run: |
           pip-compile --dry-run requirements.in

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-.PHONY: openapi check-openapi discord-run
+.PHONY: openapi openapi-check check-openapi discord-run
 openapi:
+	@python -m pip show PyYAML >/dev/null 2>&1 || pip install --quiet PyYAML
 	python scripts/generate_openapi.py
 
-check-openapi:
-	python scripts/generate_openapi.py
+openapi-check: openapi
 	git diff --exit-code openapi.json
+
+check-openapi: openapi-check
 
 discord-run:
 	python clients/discord/bot.py

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ and edit the values, or override them in `docker-compose.yml`:
 
 ### Updating `openapi.json`
 
-Run `make openapi` to regenerate `openapi.json`. This command loads `api.character_router:app` so the resulting spec documents `/chat`, `/chat/stream`, and `/manifest`. Use `make check-openapi` to ensure it stays in sync.
+Run `make openapi` to regenerate `openapi.json`. This command loads `api.character_router:app` so the resulting spec documents `/chat`, `/chat/stream`, and `/manifest`. Use `make openapi-check` to ensure it stays in sync and committed.
 
 
 ## Web Chat Widget


### PR DESCRIPTION
## Summary
- ensure PyYAML is available before generating the OpenAPI spec
- add `openapi-check` Makefile target and use it in CI
- mention the new target in contributor docs

## Testing
- `pytest -q` *(fails: command not found)*
- `make openapi-check` *(fails: network access required for pip)*