### PR TITLE
Unify Discord token config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,7 @@ OPENAI_API_KEY=sk-your-key
 OPENAI_MODEL=gpt-4
 
 # Discord bot settings
-# Token for clients/discord/bot.py
+# Token for clients/discord/bot.py and clients/discord/bridge.py
 DISCORD_TOKEN=your-discord-token
-# Token for clients/discord/bridge.py
-DISCORD_BOT_TOKEN=your-discord-token
 # API URL the Discord bot connects to
 FRENZY_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ and edit the values, or override them in `docker-compose.yml`:
 - `OPENAI_API_KEY` – your OpenAI authentication key. If omitted, the chat
   endpoints respond with `503` until a key is supplied and a warning is logged at startup.
 - `OPENAI_MODEL` – OpenAI model name (default: `gpt-4`).
-- `DISCORD_TOKEN` – bot token for `clients/discord/bot.py`.
-- `DISCORD_BOT_TOKEN` – token for `clients/discord/bridge.py`.
+- `DISCORD_TOKEN` – bot token used by `clients/discord/bot.py` and
+  `clients/discord/bridge.py`.
 - `FRENZY_API_URL` – API endpoint used by the Discord bot (default: `http://localhost:8000`).
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).

--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -24,7 +24,7 @@ and respond to messages in Discord.
 Forward messages to the REST API instead of a local persona:
 
 ```bash
-export DISCORD_BOT_TOKEN=YOUR_TOKEN
+export DISCORD_TOKEN=YOUR_TOKEN
 export FRENZY_API_URL=http://localhost:8000
 python bridge.py
 ```

--- a/clients/discord/bridge.py
+++ b/clients/discord/bridge.py
@@ -6,7 +6,7 @@ import aiohttp
 import discord
 
 API_URL = os.getenv("FRENZY_API_URL", "http://localhost:8000").rstrip("/")
-TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+TOKEN = os.getenv("DISCORD_TOKEN")
 CHARACTER = os.getenv("FRENZY_CHARACTER", "blueprint-nova")
 
 logging.basicConfig(level=logging.INFO)
@@ -74,6 +74,6 @@ async def on_message(msg: discord.Message) -> None:
 
 if __name__ == "__main__":
     if not TOKEN:
-        print("DISCORD_BOT_TOKEN environment variable not set")
+        print("DISCORD_TOKEN environment variable not set")
         raise SystemExit(1)
     client.run(TOKEN)


### PR DESCRIPTION
## Summary
- unify Discord token env var across all clients
- update README and docs
- simplify example environment file

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*