### PR TITLE
Switch discord-run to mention-only bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ openapi-check: openapi
 check-openapi: openapi-check
 
 discord-run:
-	python clients/discord/bot.py
+       python clients/discord/bridge.py

--- a/clients/discord/bridge.py
+++ b/clients/discord/bridge.py
@@ -4,6 +4,9 @@ import os
 
 import aiohttp
 import discord
+from dotenv import load_dotenv
+
+load_dotenv()
 
 API_URL = os.getenv("FRENZY_API_URL", "http://localhost:8000").rstrip("/")
 TOKEN = os.getenv("DISCORD_TOKEN")

--- a/docs/discord_setup.md
+++ b/docs/discord_setup.md
@@ -1,8 +1,8 @@
 # Discord Bot Quick Setup
 
-This project includes a small Discord bot that forwards every message to the
-API's `/chat/stream` endpoint. The bot reads environment variables from a local
-`.env` file using **python-dotenv**.
+This project includes a small Discord bot that forwards messages to the
+API's `/chat/stream` endpoint when invoked. The bot reads environment variables
+from a local `.env` file using **python-dotenv**.
 
 1. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` to your bot token.
    Adjust `FRENZY_API_URL` if your server runs on a different host.
@@ -11,6 +11,6 @@ API's `/chat/stream` endpoint. The bot reads environment variables from a local
    make discord-run
    ```
 
-The command above loads the `.env` file automatically and starts the bot.  It
-will listen to messages it can see and send the streamed reply back to the same
-channel.
+The command above loads the `.env` file automatically and starts the bot. It
+only responds when a message begins with `!gpt` or mentions the bot, sending the
+streamed reply back to the same channel.


### PR DESCRIPTION
## Summary
- run the mention-triggered bridge bot by default
- load `.env` in the bridge code
- document that `!gpt` or mentions trigger responses

## Testing
- `pytest -q` *(fails: command not found)*