### PR TITLE
Add env option for Discord persona

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ OPENAI_MODEL=gpt-4
 DISCORD_TOKEN=your-discord-token
 # API URL the Discord bot connects to
 FRENZY_API_URL=http://localhost:8000
+# Local persona directory for clients/discord/bot.py (optional)
+FRENZY_PERSONA_DIR=

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ and edit the values, or override them in `docker-compose.yml`:
 - `DISCORD_TOKEN` – bot token used by `clients/discord/bot.py` and
   `clients/discord/bridge.py`.
 - `FRENZY_API_URL` – API endpoint used by the Discord bot (default: `http://localhost:8000`).
+- `FRENZY_PERSONA_DIR` – local persona directory for `clients/discord/bot.py`.
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).
 - `REDIS_PORT` – port for Redis (default: `6379`).

--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -10,12 +10,19 @@ and respond to messages in Discord.
 2. Enable the **Message Content Intent** for your bot in the Discord
    developer portal so it can read messages. The bot sets
    `intents.message_content = True` in `bot.py`.
-3. Run the bot, passing the persona directory and your Discord token:
+3. Run the bot with a persona directory and your Discord token. You can pass
+   the path as the first argument or set `FRENZY_PERSONA_DIR` in the
+   environment:
    ```bash
+   # command-line argument
    python bot.py /path/to/persona YOUR_BOT_TOKEN
+
+   # or environment variable
+   export FRENZY_PERSONA_DIR=/path/to/persona
+   python bot.py YOUR_BOT_TOKEN
    ```
-   The persona's `generate()` coroutine will be awaited for every message
-   the bot can see and the result sent back to the same channel.
+   The persona's `generate()` coroutine will be awaited for every message the
+   bot can see and the result sent back to the same channel.
 
 `bot.py` keeps things minimal so you can adapt it to your needs.
 

--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -1,4 +1,9 @@
-"""Minimal Discord bot using either a local persona or the API."""
+"""Minimal Discord bot using either a local persona or the API.
+
+Pass the persona path as the first command-line argument or set
+``FRENZY_PERSONA_DIR`` in the environment. If no persona is provided, the bot
+falls back to calling the API specified by ``FRENZY_API_URL``.
+"""
 
 import asyncio
 import logging
@@ -18,7 +23,7 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 CHARACTER = os.getenv("FRENZY_CHARACTER", "blueprint-nova")
 
 args = sys.argv[1:]
-PERSONA_DIR = args[0] if args else None
+PERSONA_DIR = args[0] if args else os.getenv("FRENZY_PERSONA_DIR")
 if len(args) >= 2:
     TOKEN = args[1]
 
@@ -77,7 +82,9 @@ async def on_message(msg: discord.Message) -> None:
     except Exception as exc:  # pragma: no cover - runtime safety
         log.exception("Bot error: %s", exc)
         reply = (
-            "Error contacting the API." if persona is None else "Error generating reply."
+            "Error contacting the API."
+            if persona is None
+            else "Error generating reply."
         )
     await msg.channel.send(reply)
 
@@ -87,4 +94,3 @@ if __name__ == "__main__":
         print("DISCORD_TOKEN environment variable not set")
         raise SystemExit(1)
     client.run(TOKEN)
-


### PR DESCRIPTION
## Summary
- allow `FRENZY_PERSONA_DIR` environment variable in `clients/discord/bot.py`
- document the new option in the Discord bot README
- document `FRENZY_PERSONA_DIR` in `.env.example` and the main README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*