### PR TITLE
Switch OpenAI client usage

### DIFF
--- a/api/character_router.py
+++ b/api/character_router.py
@@ -21,7 +21,9 @@ if not _api_key:
     )
     client = None
 else:
-    client = openai.OpenAI(api_key=_api_key)
+    # Configure the global OpenAI client so standard API calls work
+    openai.api_key = _api_key
+    client = openai
 # Allow callers to set the OpenAI model via env with a sensible default so we
 # can easily swap models when deploying.
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4")
@@ -210,7 +212,7 @@ def chat(req: Msg, request: Request):
         raise HTTPException(status_code=404, detail="Persona not found")
     try:
         reply = (
-            client.chat.completions.create(
+            client.ChatCompletion.create(
                 model=OPENAI_MODEL,
                 messages=[
                     {"role": "system", "content": PROMPTS[req.character]},
@@ -237,7 +239,7 @@ def chat_stream(req: Msg, request: Request):
 
     def gen():
         try:
-            resp = client.chat.completions.create(
+            resp = client.ChatCompletion.create(
                 model=OPENAI_MODEL,
                 messages=[
                     {"role": "system", "content": PROMPTS[req.character]},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,7 +152,7 @@ def test_chat(monkeypatch):
     def fake_create(*args, **kwargs):
         return _types.SimpleNamespace(choices=[Choice()])
 
-    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(cr.client.ChatCompletion, "create", fake_create)
     with TestClient(cr.app) as client:
         resp = client.post(
             "/chat", json={"character": "blueprint-nova", "message": "hey"}
@@ -174,7 +174,7 @@ def test_chat_stream(monkeypatch):
 
         return [Chunk("A"), Chunk("B")]
 
-    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(cr.client.ChatCompletion, "create", fake_create)
     with TestClient(cr.app) as client:
         resp = client.post(
             "/chat/stream", json={"character": "blueprint-nova", "message": "hey"}
@@ -189,7 +189,7 @@ def test_chat_unknown_persona(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(cr.client.chat.completions, "create", boom)
+    monkeypatch.setattr(cr.client.ChatCompletion, "create", boom)
     with TestClient(cr.app) as client:
         resp = client.post("/chat", json={"character": "bogus", "message": "hi"})
         assert resp.status_code == 404
@@ -201,7 +201,7 @@ def test_chat_stream_unknown_persona(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(cr.client.chat.completions, "create", boom)
+    monkeypatch.setattr(cr.client.ChatCompletion, "create", boom)
     with TestClient(cr.app) as client:
         resp = client.post("/chat/stream", json={"character": "bogus", "message": "hi"})
         assert resp.status_code == 404
@@ -213,7 +213,7 @@ def test_chat_openai_error(monkeypatch):
     def fake_create(*args, **kwargs):
         raise RuntimeError("bad boom")
 
-    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(cr.client.ChatCompletion, "create", fake_create)
     with TestClient(cr.app) as client:
         resp = client.post(
             "/chat", json={"character": "blueprint-nova", "message": "hi"}
@@ -227,7 +227,7 @@ def test_chat_stream_openai_error(monkeypatch):
     def fake_create(*args, **kwargs):
         raise RuntimeError("kaboom")
 
-    monkeypatch.setattr(cr.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(cr.client.ChatCompletion, "create", fake_create)
     with TestClient(cr.app) as client:
         resp = client.post(
             "/chat/stream", json={"character": "blueprint-nova", "message": "hi"}

--- a/tests/test_missing_api_key.py
+++ b/tests/test_missing_api_key.py
@@ -7,7 +7,7 @@ import pytest
 
 def test_missing_openai_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    # stub openai.OpenAI so we can detect if it's called
+    # stub openai.ChatCompletion.create so we can detect if it's called
     called = False
 
     def fail(*a, **kw):
@@ -15,7 +15,9 @@ def test_missing_openai_key(monkeypatch):
         called = True
         raise AssertionError("OpenAI should not be called")
 
-    sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=fail))
+    sys.modules.setdefault(
+        "openai", types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=fail))
+    )
 
     import api.character_router as cr
     importlib.reload(cr)

--- a/tests/test_redis_fallback_integration.py
+++ b/tests/test_redis_fallback_integration.py
@@ -14,7 +14,11 @@ def fake_redis():
 def test_fallback_to_fakeredis(monkeypatch):
     monkeypatch.setenv("REDIS_URL", "redis://does-not-exist")
     sys.modules.setdefault(
-        "openai", types.SimpleNamespace(OpenAI=lambda *a, **kw: object())
+        "openai",
+        types.SimpleNamespace(
+            api_key="",
+            ChatCompletion=types.SimpleNamespace(create=lambda *a, **kw: object()),
+        ),
     )
     import api.character_router as cr
 
@@ -27,7 +31,11 @@ def test_fallback_to_fakeredis(monkeypatch):
 def test_use_fake_redis_env(monkeypatch):
     monkeypatch.setenv("USE_FAKE_REDIS", "1")
     sys.modules.setdefault(
-        "openai", types.SimpleNamespace(OpenAI=lambda *a, **kw: object())
+        "openai",
+        types.SimpleNamespace(
+            api_key="",
+            ChatCompletion=types.SimpleNamespace(create=lambda *a, **kw: object()),
+        ),
     )
     import api.character_router as cr
 


### PR DESCRIPTION
## Summary
- configure OpenAI key globally and alias the module as `client`
- use `openai.ChatCompletion.create` for chat endpoints
- update tests to patch the new call paths

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*