### PR TITLE
Add FRENZY_CHARACTER env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,7 @@ OPENAI_MODEL=gpt-4
 DISCORD_TOKEN=your-discord-token
 # API URL the Discord bot connects to
 FRENZY_API_URL=http://localhost:8000
+# Persona used by the Discord bridge (default: blueprint-nova)
+FRENZY_CHARACTER=blueprint-nova
 # Local persona directory for clients/discord/bot.py (optional)
 FRENZY_PERSONA_DIR=

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ and edit the values, or override them in `docker-compose.yml`:
 - `DISCORD_TOKEN` – bot token used by `clients/discord/bot.py` and
   `clients/discord/bridge.py`.
 - `FRENZY_API_URL` – API endpoint used by the Discord bot (default: `http://localhost:8000`).
+- `FRENZY_CHARACTER` – persona identifier for the Discord bridge (default: `blueprint-nova`).
 - `FRENZY_PERSONA_DIR` – local persona directory for `clients/discord/bot.py`.
 - `REDIS_URL` – full Redis URL (overrides host/port).
 - `REDIS_HOST` – hostname of the Redis instance (default: `redis`).

--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -33,8 +33,11 @@ Forward messages to the REST API instead of a local persona:
 ```bash
 export DISCORD_TOKEN=YOUR_TOKEN
 export FRENZY_API_URL=http://localhost:8000
+export FRENZY_CHARACTER=blueprint-nova
 python bridge.py
 ```
+`FRENZY_CHARACTER` controls which persona the bridge uses when forwarding
+messages to the API.
 
 `bridge.py` reacts when a user mentions the bot, starts a message with `!gpt`,
 or sends the bot a direct message. It forwards the remaining text to the API's

--- a/docs/discord_setup.md
+++ b/docs/discord_setup.md
@@ -5,7 +5,8 @@ API's `/chat/stream` endpoint when invoked. The bot reads environment variables
 from a local `.env` file using **python-dotenv**.
 
 1. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` to your bot token.
-   Adjust `FRENZY_API_URL` if your server runs on a different host.
+   Adjust `FRENZY_API_URL` or `FRENZY_CHARACTER` if you use a different API host
+   or persona.
 2. Run the bot:
    ```bash
    make discord-run


### PR DESCRIPTION
## Summary
- document `FRENZY_CHARACTER` in environment variable list
- add `FRENZY_CHARACTER` example in `.env.example`
- mention the variable in Discord setup docs and example commands

## Testing
- `pytest -q` *(fails: command not found)*