### PR TITLE
Clarify Discord setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,4 +292,7 @@ Grab the stubs in **`/sdk`** and call `/chat`, `/manifest` (JSON), or `/manifest
 For details on how the `manifest.yaml` file powers the character system and how to add your own entries, see [docs/manifest_system.md](docs/manifest_system.md).
 To deploy a persona directory in another host (Discord, Unreal, Unity), follow the steps in [docs/spawn_system.md](docs/spawn_system.md).
 For a Unity-specific C# example using `GptFrenzyClient`, see [docs/unity_integration.md](docs/unity_integration.md).
-For a quick Discord bot setup, see [docs/discord_setup.md](docs/discord_setup.md).
+For a quick Discord bot setup using `bridge.py`, see
+[docs/discord_setup.md](docs/discord_setup.md). Full instructions and
+customization options live in
+[clients/discord/README.md](clients/discord/README.md).

--- a/clients/discord/README.md
+++ b/clients/discord/README.md
@@ -1,7 +1,9 @@
 # Discord Integration with Spawn System
 
-This example shows how to load a persona with `gptfrenzy.core.spawn.launch()`
-and respond to messages in Discord.
+This directory contains two scripts. The recommended approach is
+`bridge.py`, which forwards Discord messages to a running API server.
+You can also load a local persona with `bot.py` using
+`gptfrenzy.core.spawn.launch()`.
 
 1. Install `discord.py`:
    ```bash
@@ -26,9 +28,10 @@ and respond to messages in Discord.
 
 `bot.py` keeps things minimal so you can adapt it to your needs.
 
-## API Bridge
+## API Bridge (Recommended)
 
-Forward messages to the REST API instead of a local persona:
+Forward messages to the REST API instead of a local persona. This is the
+simplest way to connect Discord to an already running API:
 
 ```bash
 export DISCORD_TOKEN=YOUR_TOKEN

--- a/docs/discord_setup.md
+++ b/docs/discord_setup.md
@@ -4,9 +4,12 @@ This project includes a small Discord bot that forwards messages to the
 API's `/chat/stream` endpoint when invoked. The bot reads environment variables
 from a local `.env` file using **python-dotenv**.
 
+**Make sure to enable the "Message Content Intent" for your bot in the Discord
+developer portal so it can read messages.**
+
 1. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` to your bot token.
    Adjust `FRENZY_API_URL` if your server runs on a different host.
-2. Run the bot:
+2. Run the bot (recommended method uses `bridge.py` to connect to the running API):
    ```bash
    make discord-run
    ```
@@ -14,3 +17,6 @@ from a local `.env` file using **python-dotenv**.
 The command above loads the `.env` file automatically and starts the bot. It
 only responds when a message begins with `!gpt` or mentions the bot, sending the
 streamed reply back to the same channel.
+
+For detailed usage and customization options, see
+[clients/discord/README.md](../clients/discord/README.md).


### PR DESCRIPTION
## Summary
- document Discord Message Content intent requirement
- recommend the `bridge.py` method in both Discord docs
- cross-link docs to the full Discord README
- reference the detailed Discord README from the repo root README

## Testing
- `pytest -q` *(fails: command not found)*