### PR TITLE
Add reminder for API mode in Discord bot

### DIFF
--- a/clients/discord/bot.py
+++ b/clients/discord/bot.py
@@ -93,4 +93,6 @@ if __name__ == "__main__":
     if not TOKEN:
         print("DISCORD_TOKEN environment variable not set")
         raise SystemExit(1)
+    if not PERSONA_DIR:
+        print(f"No local persona provided; using API mode with persona {CHARACTER}")
     client.run(TOKEN)


### PR DESCRIPTION
## Summary
- notify on startup when no persona directory is provided

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `make openapi-check` *(fails: Makefile missing separator)*