### PR TITLE
Improve persona name extraction for prefixed files

### DIFF
--- a/persona_selector.py
+++ b/persona_selector.py
@@ -59,7 +59,10 @@ def load_personas(dirs: List[str]) -> Dict[str, Tuple[str, str, str]]:
 
             for fname in os.listdir(d):
                 if fname.endswith("GPT_INSTRUCTIONS.txt"):
-                    m = re.search(r"([^_]+)_GPT_INSTRUCTIONS\.txt$", fname)
+                    # Grab the portion after the last underscore so files like
+                    # "!!!ATTENTION_READ_ALL!!!_supernova_GPT_INSTRUCTIONS.txt"
+                    # map to the persona "supernova".
+                    m = re.search(r"(?:.+_)?([^_]+)_GPT_INSTRUCTIONS\.txt$", fname)
                     if m:
                         instructions[m.group(1)] = os.path.join(d, fname)
 

--- a/tests/test_persona_selector.py
+++ b/tests/test_persona_selector.py
@@ -16,6 +16,11 @@ def _make_persona_files(tmp_path, name):
     (tmp_path / f"{name}_DEEP_KNOWLEDGE_data.txt").write_text("k")
 
 
+def _make_prefixed_files(tmp_path, name):
+    (tmp_path / f"!!!ATTENTION_READ_ALL!!!_{name}_GPT_INSTRUCTIONS.txt").write_text("i")
+    (tmp_path / f"!!!ATTENTION_READ_ALL!!!_DEEP_KNOWLEDGE_{name}.txt").write_text("k")
+
+
 def test_load_personas_sorted(tmp_path):
     _make_persona(tmp_path, "b")
     _make_persona(tmp_path, "a")
@@ -40,6 +45,12 @@ def test_load_personas_fallback(tmp_path):
     assert list(personas.keys()) == ["1", "2"]
     assert personas["1"][0] == "alpha"
     assert personas["2"][0] == "beta"
+
+
+def test_load_personas_prefixed_files(tmp_path):
+    _make_prefixed_files(tmp_path, "nova")
+    personas = ps.load_personas([str(tmp_path)])
+    assert personas["1"][0] == "nova"
 
 
 def test_find_file_searches_dirs(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- handle filename prefixes when extracting persona names
- add regression test for prefixed filenames

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*