### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.log
 .DS_Store
 CREATE_YOUR_OWN_GPT/
+
+# Local environment variables
+.env


### PR DESCRIPTION
## Summary
- prevent accidental commits of local environment credentials

## Testing
- `black . --check`
- `python3 -m pytest -q` *(fails: No module named pytest)*