### PR TITLE
Add docker-compose Discord bot service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ OPENAI_MODEL=gpt-4
 # Token for clients/discord/bot.py and clients/discord/bridge.py
 DISCORD_TOKEN=your-discord-token
 # API URL the Discord bot connects to
+# Use "http://api:8000" when running with docker-compose
 FRENZY_API_URL=http://localhost:8000
 # Persona used by the Discord bridge (default: blueprint-nova)
 FRENZY_CHARACTER=blueprint-nova

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ and edit the values, or override them in `docker-compose.yml`:
 - `OPENAI_MODEL` – OpenAI model name (default: `gpt-4`).
 - `DISCORD_TOKEN` – bot token used by `clients/discord/bot.py` and
   `clients/discord/bridge.py`.
-- `FRENZY_API_URL` – API endpoint used by the Discord bot (default: `http://localhost:8000`).
+- `FRENZY_API_URL` – API endpoint used by the Discord bot (default: `http://localhost:8000`; use `http://api:8000` with Docker Compose).
 - `FRENZY_CHARACTER` – persona identifier for the Discord bridge (default: `blueprint-nova`).
 - `FRENZY_PERSONA_DIR` – local persona directory for `clients/discord/bot.py`.
 - `REDIS_URL` – full Redis URL (overrides host/port).
@@ -149,6 +149,9 @@ and edit the values, or override them in `docker-compose.yml`:
   The API also automatically falls back to in-memory Redis if the configured
   server can't be reached.
 - `ALLOWED_ORIGINS` – comma-separated list for CORS (default: `*`).
+
+Once these variables are configured, run `docker-compose up` to launch the API,
+Redis, and the Discord bot in one step.
 
 ### Updating `openapi.json`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,15 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+
+  discord-bot:
+    build: .
+    env_file: .env
+    command: ["python", "clients/discord/bridge.py"]
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      # Point the bot to the API container
+      - FRENZY_API_URL=${FRENZY_API_URL:-http://api:8000}
+      # Persona used by the Discord bridge (default: "blueprint-nova")
+      - FRENZY_CHARACTER=${FRENZY_CHARACTER:-blueprint-nova}
+    depends_on: [api]

--- a/docs/discord_setup.md
+++ b/docs/discord_setup.md
@@ -7,11 +7,18 @@ from a local `.env` file using **python-dotenv**.
 1. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` to your bot token.
    Adjust `FRENZY_API_URL` or `FRENZY_CHARACTER` if you use a different API host
    or persona.
-2. Run the bot:
+2. Start both the API and Discord bot with Docker Compose:
+   ```bash
+   docker-compose up
+   ```
+   Compose builds the image, launches the FastAPI server, and then runs
+   `clients/discord/bridge.py` in a separate container. Any environment values in
+   `.env` (like `DISCORD_TOKEN`) are automatically loaded.
+
+Alternatively, you can run the bot directly with Make:
    ```bash
    make discord-run
    ```
-
-The command above loads the `.env` file automatically and starts the bot. It
-only responds when a message begins with `!gpt` or mentions the bot, sending the
-streamed reply back to the same channel.
+Both methods load `.env` automatically. The bot responds whenever a message
+mentions it, begins with `!gpt`, or arrives as a DM, streaming the reply back to
+the same channel.


### PR DESCRIPTION
## Summary
- include a discord-bot service in `docker-compose.yml`
- explain compose usage in `docs/discord_setup.md`
- document FRENZY_API_URL usage in README and `.env.example`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*