### PR TITLE
Improve env file ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ CREATE_YOUR_OWN_GPT/
 
 # Local environment variables
 .env
+.env.*


### PR DESCRIPTION
## Summary
- prevent commits of local `.env` variants by ignoring `.env.*`

## Testing
- `pytest -q` *(fails: `pytest` not found)*