### PR TITLE
Fix persona name extraction logic

### DIFF
--- a/persona_selector.py
+++ b/persona_selector.py
@@ -59,10 +59,15 @@ def load_personas(dirs: List[str]) -> Dict[str, Tuple[str, str, str]]:
 
             for fname in os.listdir(d):
                 if fname.endswith("GPT_INSTRUCTIONS.txt"):
-                    # Grab the portion after the last underscore so files like
-                    # "!!!ATTENTION_READ_ALL!!!_supernova_GPT_INSTRUCTIONS.txt"
-                    # map to the persona "supernova".
-                    m = re.search(r"(?:.+_)?([^_]+)_GPT_INSTRUCTIONS\.txt$", fname)
+                    # The instruction files may include prefixes like
+                    # "!!!ATTENTION_READ_ALL!!!_". Capture everything after the
+                    # final prefix (or simply after the last underscore) so
+                    # files such as ``!!!ATTENTION_READ_ALL!!!_supernova_GPT_INSTRUCTIONS.txt``
+                    # correctly map to the persona ``supernova``.
+                    m = re.search(
+                        r"(?:.*ATTENTION_READ_ALL!!!_)?([^_]+)_GPT_INSTRUCTIONS\.txt$",
+                        fname,
+                    )
                     if m:
                         instructions[m.group(1)] = os.path.join(d, fname)
 


### PR DESCRIPTION
## Summary
- adjust regex for instruction file names so prefixes are ignored

## Testing
- `pytest -q` *(fails: command not found)*